### PR TITLE
fix(migration): allow empty event_teams table in production deploy

### DIFF
--- a/db/migrate/20260707123000_add_slot_and_rename_name_to_label_on_event_teams.rb
+++ b/db/migrate/20260707123000_add_slot_and_rename_name_to_label_on_event_teams.rb
@@ -30,46 +30,90 @@ class AddSlotAndRenameNameToLabelOnEventTeams < ActiveRecord::Migration[8.0]
   ORDERED_SLOTS = %w[team_one team_two bench].freeze
   LABEL_MAX_LENGTH = 255
 
-  class EventTeam < ApplicationRecord
+  class MigrationEventTeam < ApplicationRecord
     self.table_name = "event_teams"
   end
 
   def up
-    add_column :event_teams, :slot, :string
-    rename_column :event_teams, :name, :label
+    if recreate_empty_legacy_table?
+      recreate_empty_event_teams_table!
+      return
+    end
 
-    backfill_slots
-    deduplicate_labels_per_event
-
-    change_column_null :event_teams, :slot, false
-    add_index :event_teams, %i[event_id slot], unique: true
-    add_index :event_teams, %i[event_id label], unique: true
+    add_slot_and_label_columns!
+    migrate_event_team_rows if event_teams_count.positive?
+    finalize_event_teams_table!
   end
 
   def down
-    remove_index :event_teams, column: %i[event_id label]
-    remove_index :event_teams, column: %i[event_id slot]
-    remove_column :event_teams, :slot
-    rename_column :event_teams, :label, :name
+    remove_index :event_teams, column: %i[event_id label], if_exists: true
+    remove_index :event_teams, column: %i[event_id slot], if_exists: true
+    change_column_null :event_teams, :slot, true if column_exists?(:event_teams, :slot)
+    remove_column :event_teams, :slot if column_exists?(:event_teams, :slot)
+    rename_column :event_teams, :label, :name if column_exists?(:event_teams, :label)
   end
 
   private
 
+  def recreate_empty_legacy_table?
+    event_teams_count.zero? &&
+      column_exists?(:event_teams, :name) &&
+      !column_exists?(:event_teams, :event_id)
+  end
+
+  def recreate_empty_event_teams_table!
+    say_with_time "Recreating empty legacy event_teams table (id/name only)" do
+      drop_table :event_teams
+      create_table :event_teams do |t|
+        t.string :label, null: false
+        t.references :event, null: false, foreign_key: true
+        t.string :slot, null: false
+        t.timestamps
+      end
+      add_index :event_teams, %i[event_id slot], unique: true
+      add_index :event_teams, %i[event_id label], unique: true
+    end
+  end
+
+  def add_slot_and_label_columns!
+    add_column :event_teams, :slot, :string unless column_exists?(:event_teams, :slot)
+    rename_column :event_teams, :name, :label if column_exists?(:event_teams, :name)
+  end
+
+  def finalize_event_teams_table!
+    change_column_null :event_teams, :slot, false
+    add_index :event_teams, %i[event_id slot], unique: true unless index_exists?(:event_teams, %i[event_id slot])
+    add_index :event_teams, %i[event_id label], unique: true unless index_exists?(:event_teams, %i[event_id label])
+  end
+
+  def migrate_event_team_rows
+    unless column_exists?(:event_teams, :event_id)
+      raise ActiveRecord::IrreversibleMigration, "event_teams.event_id is required to backfill rows"
+    end
+
+    backfill_slots
+    deduplicate_labels_per_event
+  end
+
+  def event_teams_count
+    select_value("SELECT COUNT(*) FROM event_teams").to_i
+  end
+
   def backfill_slots
     say_with_time "Backfilling event_team slots (locale defaults + creation order)" do
-      EventTeam.reset_column_information
+      MigrationEventTeam.reset_column_information
 
-      EventTeam.distinct.pluck(:event_id).each do |event_id|
+      MigrationEventTeam.distinct.pluck(:event_id).each do |event_id|
         backfill_slots_for_event(event_id)
       end
 
-      remaining = EventTeam.where(slot: nil).count
+      remaining = MigrationEventTeam.where(slot: nil).count
       raise ActiveRecord::IrreversibleMigration, "#{remaining} event_teams still missing slot" if remaining.positive?
     end
   end
 
   def backfill_slots_for_event(event_id)
-    teams = EventTeam.where(event_id: event_id).order(:id)
+    teams = MigrationEventTeam.where(event_id: event_id).order(:id)
     team_count = teams.count
 
     if team_count > ORDERED_SLOTS.size
@@ -88,7 +132,7 @@ class AddSlotAndRenameNameToLabelOnEventTeams < ActiveRecord::Migration[8.0]
       taken_slots << slot
     end
 
-    EventTeam.where(event_id: event_id, slot: nil).order(:id).each do |team|
+    MigrationEventTeam.where(event_id: event_id, slot: nil).order(:id).each do |team|
       slot = (ORDERED_SLOTS - taken_slots).first
       raise ActiveRecord::IrreversibleMigration,
             "No slot left for event_team #{team.id} (event #{event_id})" unless slot
@@ -100,13 +144,13 @@ class AddSlotAndRenameNameToLabelOnEventTeams < ActiveRecord::Migration[8.0]
 
   def deduplicate_labels_per_event
     say_with_time "Deduplicating event_team labels (case-insensitive, per event)" do
-      EventTeam.reset_column_information
+      MigrationEventTeam.reset_column_information
 
-      EventTeam.distinct.pluck(:event_id).each do |event_id|
+      MigrationEventTeam.distinct.pluck(:event_id).each do |event_id|
         used_labels = {}
         used_normalized_labels = {}
 
-        EventTeam.where(event_id: event_id).order(:id).each do |team|
+        MigrationEventTeam.where(event_id: event_id).order(:id).each do |team|
           current_label = team.label.to_s
           key = normalize_label(current_label)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deploys fail during `db:prepare` on migration `20260707123000_add_slot_and_rename_name_to_label_on_event_teams` (see PR #58 / CI deploy job).

Production currently has:
- no `events` rows
- no `event_teams` rows
- `event_teams` still on the legacy schema (`name`, no `slot`)

The migration always ran backfill/deduplication logic that queries `event_id` and updates rows. On an empty legacy table this is unnecessary, and when the table only has `id`/`name` the first `pluck(:event_id)` raises a PostgreSQL error; subsequent statements then fail with `PG::InFailedSqlTransaction`, which matches the Kamal logs.

## Fix

- **Empty table fast path**: skip row backfill/deduplication when `event_teams` has zero rows
- **Legacy empty table**: if the table only has `id`/`name`, drop and recreate it with the target schema (`label`, `slot`, `event_id`, indexes)
- **Safer deploy restarts**: idempotent `add_column` / `rename_column` / `add_index` guards for Kamal health-check retries
- **Isolation**: use `MigrationEventTeam` instead of a nested `EventTeam` constant to avoid collisions with the application model during `db:prepare`

## Verification

- SQL simulation of both paths (empty standard schema + empty legacy `id`/`name`) succeeds locally
- CI `db:test:prepare` is unchanged (loads `schema.rb`); this unblocks the production `db:migrate` path

After merge, the next deploy to `master` should pass `db:prepare` and boot successfully.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca8b51c9-e924-4f23-b714-3bcc10d37f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca8b51c9-e924-4f23-b714-3bcc10d37f25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

