### PR TITLE
fix(migration): schema-only slot/label change, defaults in Event model

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ApplicationRecord
   TRACKED_NOTIFICATION_FIELDS = %w[title start_time price number_of_participants].freeze
   TEAM_SLOTS = %w[team_one team_two bench].freeze
+  SLOT_DEFAULT_LABEL_KEYS = TEAM_SLOTS.index_with { |slot| "event_team.slots.#{slot}.default_label" }.freeze
 
   belongs_to :user
   has_many :event_teams, dependent: :destroy
@@ -23,6 +24,10 @@ class Event < ApplicationRecord
   before_destroy :prepare_cancellation_notifications, prepend: true
   after_destroy_commit :notify_cancellation
 
+  def self.default_label_for(slot)
+    I18n.t(SLOT_DEFAULT_LABEL_KEYS.fetch(slot.to_s))
+  end
+
   def self.visible_to(user)
     return none if user.blank?
 
@@ -38,7 +43,7 @@ class Event < ApplicationRecord
 
   def set_teams_and_author
     TEAM_SLOTS.each do |slot|
-      event_teams.create!(slot: slot, label: I18n.t("event_team.slots.#{slot}.default_label"))
+      event_teams.create!(slot: slot, label: self.class.default_label_for(slot))
     end
     event_participants.create!(user: user, event_team: event_teams.find_by!(slot: :team_one))
   end

--- a/db/migrate/20260707123000_add_slot_and_rename_name_to_label_on_event_teams.rb
+++ b/db/migrate/20260707123000_add_slot_and_rename_name_to_label_on_event_teams.rb
@@ -3,9 +3,6 @@ class AddSlotAndRenameNameToLabelOnEventTeams < ActiveRecord::Migration[8.0]
     add_column :event_teams, :slot, :string
     rename_column :event_teams, :name, :label
 
-    backfill_slots
-    deduplicate_labels_per_event
-
     change_column_null :event_teams, :slot, false
     add_index :event_teams, %i[event_id slot], unique: true
     add_index :event_teams, %i[event_id label], unique: true
@@ -16,74 +13,5 @@ class AddSlotAndRenameNameToLabelOnEventTeams < ActiveRecord::Migration[8.0]
     remove_index :event_teams, column: %i[event_id slot]
     remove_column :event_teams, :slot
     rename_column :event_teams, :label, :name
-  end
-
-  private
-
-  def backfill_slots
-    say_with_time "Backfilling event_team slots (locale defaults + creation order)" do
-      EventTeam.reset_column_information
-
-      EventTeam.distinct.pluck(:event_id).each do |event_id|
-        backfill_slots_for_event(event_id)
-      end
-
-      remaining = EventTeam.where(slot: nil).count
-      raise ActiveRecord::IrreversibleMigration, "#{remaining} event_teams still missing slot" if remaining.positive?
-    end
-  end
-
-  def backfill_slots_for_event(event_id)
-    teams = EventTeam.where(event_id: event_id).order(:id)
-    team_count = teams.count
-
-    if team_count > ORDERED_SLOTS.size
-      raise ActiveRecord::IrreversibleMigration,
-            "event #{event_id} has #{team_count} teams (max #{ORDERED_SLOTS.size})"
-    end
-
-    taken_slots = []
-
-    teams.each do |team|
-      slot = SLOT_BY_LABEL[normalize_label(team.label)]
-      next unless slot
-      next if taken_slots.include?(slot)
-
-      team.update_columns(slot: slot)
-      taken_slots << slot
-    end
-
-    EventTeam.where(event_id: event_id, slot: nil).order(:id).each do |team|
-      slot = (ORDERED_SLOTS - taken_slots).first
-      raise ActiveRecord::IrreversibleMigration,
-            "No slot left for event_team #{team.id} (event #{event_id})" unless slot
-
-      team.update_columns(slot: slot)
-      taken_slots << slot
-    end
-  end
-
-  def deduplicate_labels_per_event
-    say_with_time "Deduplicating event_team labels (case-insensitive, per event)" do
-      EventTeam.reset_column_information
-
-      EventTeam.distinct.pluck(:event_id).each do |event_id|
-        seen_normalized_labels = {}
-
-        EventTeam.where(event_id: event_id).order(:id).each do |team|
-          key = normalize_label(team.label)
-
-          if seen_normalized_labels[key]
-            team.update_columns(label: "#{team.label} (#{team.id})")
-          else
-            seen_normalized_labels[key] = true
-          end
-        end
-      end
-    end
-  end
-
-  def normalize_label(label)
-    label.to_s.strip.downcase
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The last migration (`20260707123000`) still contained backfill/deduplication logic referencing `ORDERED_SLOTS` and `SLOT_BY_LABEL`, but those constants were removed in a bad merge — causing deployment failures.

## Solution

- **Migration**: reduced to a pure schema change — add `:slot`, rename `:name` → `:label`, set `NOT NULL`, add unique indexes. No application code, no backfill.
- **Event model**: centralized slot names and default label resolution:
  - `TEAM_SLOTS` (unchanged)
  - `SLOT_DEFAULT_LABEL_KEYS` — I18n key per slot
  - `Event.default_label_for(slot)` — used by `set_teams_and_author`

This matches the emptied-DB deployment scenario: fresh `db:migrate` or `db:schema:load` works without legacy data backfill.

## Notes

Default labels still come from `config/locales/<locale>/event_team.yml` via I18n; only the mapping lives in the model now, not in migrations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b00b1cb-22bd-46cf-9490-04650ad8b622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b00b1cb-22bd-46cf-9490-04650ad8b622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

