### PR TITLE
Update environment configuration and enhance test setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,9 @@
 # Required for bin/dev and db:migrate:
 DEVELOPMENT_NEON_DB=postgresql://user:pass@host/neondb?sslmode=require
 
-# Required for bundle exec rspec (use a separate Neon branch/database — never dev or prod):
-TEST_NEON_DB=postgresql://user:pass@host/neondb_test?sslmode=require
+# Required for bundle exec rspec (separate Neon branch — never dev or prod).
+# Prefer the direct (non-pooler) host so db:test:purge is not blocked by PG::ObjectInUse:
+TEST_NEON_DB=postgresql://user:pass@ep-xxxx.eu-central-1.aws.neon.tech/neondb_test?sslmode=require
 
 # Deploy only (.kamal/secrets / GitHub secret PRODUCTION_NEON_DB):
 PRODUCTION_NEON_DB=postgresql://user:pass@host/neondb_prod?sslmode=require

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module FlipflappFullstack
     config.time_zone = "Paris"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :fr
+    config.i18n.fallbacks = [ :en ]
   end
 end
+

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,10 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Neon (and other shared DBs) often cannot DROP/purge while pooler sessions linger
+  # (PG::ObjectInUse). Keep destructive schema rebuild for CI ephemeral DBs only;
+  # locally run `RAILS_ENV=test bin/rails db:migrate` when migrations are pending.
+  config.active_record.maintain_test_schema = ENV["CI"].present?
 end
+

--- a/config/locales/fr/activerecord.yml
+++ b/config/locales/fr/activerecord.yml
@@ -1,0 +1,8 @@
+fr:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "La validation a échoué : %{errors}"
+        restrict_dependent_destroy:
+          has_one: "Impossible de supprimer l'enregistrement car un(e) %{record} dépendant(e) existe"
+          has_many: "Impossible de supprimer l'enregistrement car des %{record} dépendant(e)s existent"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,6 +55,8 @@ Copy `.env.example` → `.env`. Wired in `config/database.yml`.
 
 Use **separate** Neon databases (or branches) for development and test. Never point local env at production.
 
+For `TEST_NEON_DB`, prefer Neon’s **direct** host (not `-pooler`). Locally, Rails does not purge/rebuild the test DB on each `rspec` run (that triggers `PG::ObjectInUse` on Neon); apply schema with `RAILS_ENV=test bin/rails db:migrate`. CI still rebuilds the schema.
+
 Production URL (`PRODUCTION_NEON_DB`) is for deploy only — see [DEPLOYMENT.md](DEPLOYMENT.md). Kamal does not read `.env`.
 
 ### Local `.env` (typical)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,9 @@
+require "securerandom"
+
 FactoryBot.define do
   factory :user do
-    sequence(:email) { |n| "user#{n}@example.com" }
+    # SecureRandom avoids collisions when the test DB could not be purged (Neon pooler).
+    sequence(:email) { |n| "user#{n}.#{SecureRandom.hex(4)}@example.com" }
     password { "password123" }
     password_confirmation { "password123" }
     first_name { Faker::Name.first_name }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,15 +25,30 @@ require 'rspec/rails'
 #
 Rails.root.glob("spec/support/**/*.rb").sort_by(&:to_s).each { |f| require f }
 
-# Ensures that the test database schema matches the current schema file.
-# If there are pending migrations it will invoke `db:test:prepare` to
-# recreate the test database by loading the schema.
-# If you are not using ActiveRecord, you can remove these lines.
-begin
-  ActiveRecord::Migration.maintain_test_schema!
-rescue ActiveRecord::PendingMigrationError => e
-  abort e.to_s.strip
+# Ensures migrations are applied. Destructive schema rebuild (purge + load) is
+# enabled only when CI=true — see config/environments/test.rb.
+if ActiveRecord.maintain_test_schema
+  begin
+    ActiveRecord::Migration.maintain_test_schema!
+  rescue ActiveRecord::PendingMigrationError => e
+    abort e.to_s.strip
+  rescue ActiveRecord::StatementInvalid => e
+    raise unless /ObjectInUse|being accessed by other users/i.match?(e.message)
+
+    warn <<~MSG
+      ⚠️  Could not rebuild the test database (PG::ObjectInUse). Continuing with the existing schema.
+         Prefer a non-pooler TEST_NEON_DB URL, or run: RAILS_ENV=test bin/rails db:migrate
+    MSG
+  end
+elsif ActiveRecord::Base.connection_pool.migration_context.needs_migration?
+  abort <<~MSG
+    Pending migrations in the test database. Run:
+
+        RAILS_ENV=test bin/rails db:migrate
+  MSG
 end
+
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [


### PR DESCRIPTION
- Modified `.env.example` to specify a direct host for `TEST_NEON_DB` to avoid issues with database purging.
- Added fallback locale configuration in `application.rb` for improved internationalization support.
- Updated `test.rb` to conditionally maintain the test schema based on the CI environment variable, ensuring better handling of database migrations.
- Introduced a new French locale file for ActiveRecord error messages to enhance localization.
- Improved `rails_helper.rb` to provide clearer instructions for handling test database migrations and potential errors.
- Updated user factory to use `SecureRandom` for email generation, preventing collisions when the test database cannot be purged.