### PR TITLE
Implement declined friendship handling in the FriendshipsController

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,10 +1,14 @@
 class FriendshipsController < ApplicationController
   before_action :authenticate_user!
 
+  TABS = %w[friends received sent declined].freeze
+
   def index
     @accepted_friendships = current_user.accepted_friendships.includes(:sender, :receiver)
     @sent_friendships = current_user.pending_sent_friendships.includes(:receiver)
     @received_friendships = current_user.pending_received_friendships.includes(:sender)
+    @declined_friendships = current_user.declined_received_friendships.includes(:sender)
+    @tab = resolve_tab
   end
 
   def search
@@ -30,9 +34,20 @@ class FriendshipsController < ApplicationController
 
   def update
     friendship = Friendship.find(params[:id])
-    @user = friendship.sender
-    if friendship.receiver == current_user && friendship.update(status: "accepted")
-      redirect_to friendships_path, notice: t("friendships.flash.update.success", name: @user.first_name)
+
+    unless friendship.receiver == current_user && friendship.status == "pending"
+      redirect_to friendships_path, alert: t("friendships.flash.update.failure")
+      return
+    end
+
+    if params[:status] == "declined"
+      if friendship.decline
+        redirect_to friendships_path(tab: "declined"), alert: t("friendships.flash.update.declined")
+      else
+        redirect_to friendships_path, alert: t("friendships.flash.update.failure")
+      end
+    elsif friendship.accept
+      redirect_to friendships_path(tab: "friends"), notice: t("friendships.flash.update.success", name: friendship.sender.first_name)
     else
       redirect_to friendships_path, alert: t("friendships.flash.update.failure")
     end
@@ -41,21 +56,30 @@ class FriendshipsController < ApplicationController
   def destroy
     friendship = Friendship.find(params[:id])
 
-    if friendship.receiver == current_user && friendship.status == "pending"
+    if friendship.receiver == current_user && friendship.status == "declined"
       friendship.destroy
-      redirect_back fallback_location: friendships_path, alert: t("friendships.flash.destroy.declined")
+      redirect_to friendships_path(tab: "friends"), notice: t("friendships.flash.destroy.removed_declined")
 
     elsif (friendship.sender == current_user || friendship.receiver == current_user) && friendship.status == "accepted"
       other_user = friendship.sender == current_user ? friendship.receiver : friendship.sender
       friendship.destroy
-      redirect_back fallback_location: friendships_path, alert: t("friendships.flash.destroy.unfriended", name: other_user.first_name)
+      redirect_to friendships_path(tab: "friends"), alert: t("friendships.flash.destroy.unfriended", name: other_user.first_name)
 
     elsif friendship.sender == current_user && friendship.status == "pending"
       friendship.destroy
-      redirect_back fallback_location: friendships_path, alert: t("friendships.flash.destroy.cancelled")
+      redirect_to friendships_path(tab: "sent"), alert: t("friendships.flash.destroy.cancelled")
 
     else
       redirect_back fallback_location: friendships_path, alert: t("friendships.flash.destroy.unauthorized")
     end
+  end
+
+  private
+
+  def resolve_tab
+    tab = TABS.include?(params[:tab]) ? params[:tab] : "friends"
+    return "friends" if tab == "declined" && @declined_friendships.empty?
+
+    tab
   end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -23,6 +23,7 @@ class Friendship < ApplicationRecord
 
   scope :pending, -> { where(status: "pending") }
   scope :accepted, -> { where(status: "accepted") }
+  scope :declined, -> { where(status: "declined") }
 
   def self.accepted_friend_ids_for(user)
     accepted
@@ -34,10 +35,14 @@ class Friendship < ApplicationRecord
   end
 
   def accept
+    return false unless pending?
+
     update(status: "accepted")
   end
 
   def decline
+    return false unless pending?
+
     update(status: "declined")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,12 @@ class User < ApplicationRecord
           foreign_key: "receiver_id",
           inverse_of: :receiver
 
+  has_many :declined_received_friendships,
+          -> { declined },
+          class_name: "Friendship",
+          foreign_key: "receiver_id",
+          inverse_of: :receiver
+
   # Méthode pour combiner les deux
   def accepted_friendships
     Friendship.where(status: "accepted")

--- a/app/views/friendships/components/_avatar.html.erb
+++ b/app/views/friendships/components/_avatar.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (user:) %>
+<div class="size-10 rounded-full shadow-lg col-span-1 place-self-center">
+  <div class="w-full h-full rounded-full overflow-hidden bg-linear-to-r from-amber-400 to-amber-600 flex items-center justify-center">
+    <% if user.avatar? %>
+      <%= cl_image_tag user.avatar, class: "w-full h-full object-cover rounded-full" %>
+    <% else %>
+      <svg width="24" height="24" viewBox="0 0 0.6 0.6" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="text-white" aria-hidden="true">
+        <path d="M.44.06a.06.06 0 1 1-.12 0 .06.06 0 0 1 .12 0m0 .38a.04.04 0 1 0 0 .08.04.04 0 0 0 0-.08M.514.244.438.168A.02.02 0 0 0 .423.161H.14a.02.02 0 0 0 0 .04h.108L.12.452V.46a.02.02 0 0 0 .04.008L.2.4h.08L.203.57.2.58a.02.02 0 0 0 .04.008L.428.213l.058.059A.02.02 0 0 0 .514.244"/>
+      </svg>
+    <% end %>
+  </div>
+</div>

--- a/app/views/friendships/components/_one_declined.html.erb
+++ b/app/views/friendships/components/_one_declined.html.erb
@@ -1,0 +1,22 @@
+<%# locals: (friendship:) %>
+<div class="rounded-2xl bg-white/5 backdrop-blur-md shadow-xl p-4 hover:bg-white/10 transition-colors">
+  <div class="grid grid-cols-6 items-center gap-2">
+    <%= render "friendships/components/avatar", user: friendship.sender %>
+
+    <ul class="col-span-4">
+      <%= link_to user_path(friendship.sender) do %>
+        <li class="font-semibold text-white"><%= friendship.sender.first_name %></li>
+        <li class="text-secondary-text text-sm">@<%= friendship.sender.username %></li>
+        <li class="text-secondary-text text-xs mt-1"><%= t("friendships.labels.declined_by_you") %></li>
+      <% end %>
+    </ul>
+
+    <div class="col-span-1 place-self-center">
+      <%= button_to friendship_path(friendship), method: :delete, class: "flex-1 bg-gray-600 active:bg-gray-800 text-white font-medium p-2 rounded-lg transition-colors place-content-center", data: { turbo_confirm: t("friendships.confirms.remove_declined") }, aria: { label: t("friendships.actions.remove_declined") } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/friendships/components/_one_friend.html.erb
+++ b/app/views/friendships/components/_one_friend.html.erb
@@ -1,0 +1,30 @@
+<%# locals: (friendship:, current_user:) %>
+<% friend = friendship.sender == current_user ? friendship.receiver : friendship.sender %>
+<div class="rounded-2xl bg-white/5 backdrop-blur-md shadow-xl p-4 hover:bg-white/10 transition-colors">
+  <div class="grid grid-cols-6 items-center gap-2">
+    <%= render "friendships/components/avatar", user: friend %>
+
+    <ul class="col-span-3">
+      <%= link_to user_path(friend) do %>
+        <li class="font-semibold text-white"><%= friend.first_name %></li>
+        <li class="text-secondary-text text-sm">@<%= friend.username %></li>
+      <% end %>
+    </ul>
+
+    <div class="col-span-1 place-self-center">
+      <%= link_to user_path(friend), class: "block flex-1 bg-primary-yellow active:bg-yellow-600 text-white font-medium p-2 rounded-lg transition-colors place-content-center", aria: { label: friend.first_name } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+      <% end %>
+    </div>
+
+    <div class="col-span-1 place-self-center">
+      <%= button_to friendship_path(friendship), method: :delete, class: "flex-1 bg-red-600 active:bg-red-800 text-white font-medium p-2 rounded-lg transition-colors place-content-center", data: { turbo_confirm: t("friendships.confirms.remove", name: friend.first_name) }, aria: { label: t("friendships.actions.remove") } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/friendships/components/_one_received.html.erb
+++ b/app/views/friendships/components/_one_received.html.erb
@@ -1,0 +1,29 @@
+<%# locals: (friendship:) %>
+<div class="rounded-2xl bg-white/5 backdrop-blur-md shadow-xl p-4 hover:bg-white/10 transition-colors">
+  <div class="grid grid-cols-6 items-center gap-2">
+    <%= render "friendships/components/avatar", user: friendship.sender %>
+
+    <ul class="col-span-3">
+      <%= link_to user_path(friendship.sender) do %>
+        <li class="font-semibold text-white"><%= friendship.sender.first_name %></li>
+        <li class="text-secondary-text text-sm">@<%= friendship.sender.username %></li>
+      <% end %>
+    </ul>
+
+    <div class="col-span-1 place-self-center">
+      <%= button_to friendship_path(friendship), method: :patch, class: "flex-1 bg-form-green active:bg-green-600 text-white font-medium p-2 rounded-lg transition-colors place-content-center", aria: { label: t("friendships.actions.accept") } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+      <% end %>
+    </div>
+
+    <div class="col-span-1 place-self-center">
+      <%= button_to friendship_path(friendship), method: :patch, params: { status: "declined" }, class: "flex-1 bg-red-600 active:bg-red-800 text-white font-medium p-2 rounded-lg transition-colors place-content-center", data: { turbo_confirm: t("friendships.confirms.decline") }, aria: { label: t("friendships.actions.decline") } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/friendships/components/_one_sent.html.erb
+++ b/app/views/friendships/components/_one_sent.html.erb
@@ -1,0 +1,21 @@
+<%# locals: (friendship:) %>
+<div class="rounded-2xl bg-white/5 backdrop-blur-md shadow-xl p-4 hover:bg-white/10 transition-colors">
+  <div class="grid grid-cols-6 items-center gap-2">
+    <%= render "friendships/components/avatar", user: friendship.receiver %>
+
+    <ul class="col-span-4">
+      <%= link_to user_path(friendship.receiver) do %>
+        <li class="font-semibold text-white"><%= friendship.receiver.first_name %></li>
+        <li class="text-secondary-text text-sm">@<%= friendship.receiver.username %></li>
+      <% end %>
+    </ul>
+
+    <div class="col-span-1 place-self-center">
+      <%= button_to friendship_path(friendship), method: :delete, class: "flex-1 bg-gray-600 active:bg-gray-800 text-white font-medium p-2 rounded-lg transition-colors place-content-center", data: { turbo_confirm: t("friendships.confirms.cancel") }, aria: { label: t("friendships.actions.cancel_request") } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/friendships/components/_section_declined.html.erb
+++ b/app/views/friendships/components/_section_declined.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (friendships:) %>
+<section>
+  <h2 class="sr-only"><%= t("friendships.titles.declined") %></h2>
+
+  <div class="grid grid-cols-1 gap-4">
+    <% friendships.each do |friendship| %>
+      <%= render "friendships/components/one_declined", friendship: friendship %>
+    <% end %>
+  </div>
+</section>

--- a/app/views/friendships/components/_section_friends.html.erb
+++ b/app/views/friendships/components/_section_friends.html.erb
@@ -1,0 +1,18 @@
+<%# locals: (friendships:, current_user:) %>
+<section>
+  <h2 class="sr-only"><%= t("friendships.titles.friends") %></h2>
+
+  <% if friendships.empty? %>
+    <div class="text-center py-12 text-secondary-text">
+      <p class="text-lg"><%= t("friendships.empty.friends") %></p>
+      <p class="text-sm mt-2"><%= t("friendships.empty.friends_hint") %></p>
+      <%= link_to t("friendships.actions.search"), search_friendships_path, class: "mt-6 inline-block bg-primary-yellow text-white py-2 px-4 rounded-lg font-semibold hover:bg-yellow-500 transition" %>
+    </div>
+  <% else %>
+    <div class="grid grid-cols-1 gap-4">
+      <% friendships.each do |friendship| %>
+        <%= render "friendships/components/one_friend", friendship: friendship, current_user: current_user %>
+      <% end %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/friendships/components/_section_received.html.erb
+++ b/app/views/friendships/components/_section_received.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (friendships:) %>
+<section>
+  <h2 class="sr-only"><%= t("friendships.titles.received") %></h2>
+
+  <% if friendships.empty? %>
+    <div class="text-center py-12 text-secondary-text">
+      <p><%= t("friendships.empty.received") %></p>
+    </div>
+  <% else %>
+    <div class="grid grid-cols-1 gap-4">
+      <% friendships.each do |friendship| %>
+        <%= render "friendships/components/one_received", friendship: friendship %>
+      <% end %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/friendships/components/_section_sent.html.erb
+++ b/app/views/friendships/components/_section_sent.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (friendships:) %>
+<section>
+  <h2 class="sr-only"><%= t("friendships.titles.sent") %></h2>
+
+  <% if friendships.empty? %>
+    <div class="text-center py-12 text-secondary-text">
+      <p><%= t("friendships.empty.sent") %></p>
+    </div>
+  <% else %>
+    <div class="grid grid-cols-1 gap-4">
+      <% friendships.each do |friendship| %>
+        <%= render "friendships/components/one_sent", friendship: friendship %>
+      <% end %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/friendships/components/_tabs.html.erb
+++ b/app/views/friendships/components/_tabs.html.erb
@@ -1,0 +1,32 @@
+<%# locals: (tab:, received_count:, sent_count:, friends_count:, declined_count:) %>
+<%
+  tabs = [
+    { key: "friends", title: t("friendships.titles.friends"), count: friends_count },
+    { key: "received", title: t("friendships.titles.received"), count: received_count },
+    { key: "sent", title: t("friendships.titles.sent"), count: sent_count }
+  ]
+  tabs << { key: "declined", title: t("friendships.titles.declined"), count: declined_count } if declined_count.positive?
+%>
+
+<nav class="mb-8 overflow-x-auto" aria-label="<%= t("friendships.aria.tabs") %>">
+  <ul class="flex gap-2 min-w-max">
+    <% tabs.each do |item| %>
+      <% active = tab == item[:key] %>
+      <li>
+        <%= link_to friendships_path(tab: item[:key]),
+              class: [
+                "inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition-colors",
+                active ? "bg-primary-yellow text-white" : "bg-white/5 text-secondary-text hover:bg-white/10 hover:text-white"
+              ].join(" "),
+              aria: { current: (active ? "page" : nil) } do %>
+          <span><%= item[:title] %></span>
+          <% if item[:count].positive? %>
+            <span class="<%= active ? "bg-white/20" : "bg-linear-to-r from-amber-400 to-amber-600" %> flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-white text-xs font-bold">
+              <%= item[:count] %>
+            </span>
+          <% end %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -1,243 +1,26 @@
-<main class="min-h-dvh px-4">
-  <h1 class="text-3xl font-bold text-white text-center my-8"><%= t("friendships.titles.index") %></h1>
+<main class="min-h-dvh px-4 pb-8">
+  <div class="max-w-2xl mx-auto">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 my-8">
+      <h1 class="text-3xl font-bold text-white text-center sm:text-left"><%= t("friendships.titles.index") %></h1>
+      <%= link_to t("friendships.actions.search"), search_friendships_path, class: "inline-block text-center bg-primary-yellow text-white py-2 px-4 rounded-lg font-semibold hover:bg-yellow-500 transition" %>
+    </div>
 
-  <%= link_to t("friendships.actions.search"), search_friendships_path, class: "mb-4 inline-block bg-primary-yellow text-white py-2 px-4 rounded-lg font-semibold hover:bg-yellow-500 transition" %>
+    <%= render "friendships/components/tabs",
+          tab: @tab,
+          received_count: @received_friendships.size,
+          sent_count: @sent_friendships.size,
+          friends_count: @accepted_friendships.size,
+          declined_count: @declined_friendships.size %>
 
-    <!-- Demandes reçues (pending) -->
-    <section class="my-8">
-
-      <div id="header-recieved-requests" class="grid grid-cols-6 gap-1 mb-4 items-center">
-        <div class="col-span-1 place-self-center">
-          <svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-secondary-text" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0H4m16 0l-2-2m0 0l-2-2m2 2l2-2M4 13l2-2m0 0l2-2m-2 2l-2-2" />
-          </svg>
-        </div>
-
-        <h2 class="text-xl col-span-4 text-white">
-          <%= t("friendships.titles.received") %>
-        </h2>
-
-        <% if @received_friendships.any? %>
-          <div class="col-span-1 place-self-center">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-linear-to-r from-amber-400 to-amber-600 text-white text-xs font-bold">
-              <%= @received_friendships.count %>
-            </span>
-          </div>
-
-        <% end %>
-
-      </div>
-
-      <% if @received_friendships.empty? %>
-        <div class="text-center py-8 text-secondary-text">
-          <p><%= t("friendships.empty.received") %></p>
-        </div>
-
-      <% else %>
-        <div class="grid grid-cols-1 gap-4">
-          <% @received_friendships.each do |friendship| %>
-            <div class="rounded-2xl bg-white/5 backdrop-blur-md shadow-xl p-4 hover:bg-white/10 transition-colors">
-              <div class="grid grid-cols-6 items-center gap-2">
-                <!-- Avatar -->
-                <div class="size-10 rounded-full shadow-lg col-span-1 place-self-center">
-                  <div class="w-full h-full rounded-full overflow-hidden bg-linear-to-r from-amber-400 to-amber-600 flex items-center justify-center">
-
-                    <% if friendship.sender.avatar? %>
-                      <%= cl_image_tag friendship.sender.avatar, class: "w-full h-full object-cover rounded-full" %>
-
-                    <% else %>
-                      <svg width="24" height="24" viewBox="0 0 0.6 0.6" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="text-white">
-                        <path d="M.44.06a.06.06 0 1 1-.12 0 .06.06 0 0 1 .12 0m0 .38a.04.04 0 1 0 0 .08.04.04 0 0 0 0-.08M.514.244.438.168A.02.02 0 0 0 .423.161H.14a.02.02 0 0 0 0 .04h.108L.12.452V.46a.02.02 0 0 0 .04.008L.2.4h.08L.203.57.2.58a.02.02 0 0 0 .04.008L.428.213l.058.059A.02.02 0 0 0 .514.244"/>
-                      </svg>
-                    <% end %>
-                  </div>
-                </div>
-
-                <!-- Infos -->
-                <ul class="col-span-3">
-                  <%= link_to user_path(friendship.sender) do %>
-                    <li class="font-semibold text-white"><%= friendship.sender.first_name %></li>
-                    <li class="text-secondary-text text-sm">@<%= friendship.sender.username %></li>
-                  <% end %>
-                </ul>
-
-                <div class="col-span-1 place-self-center">
-                  <%= button_to friendship_path(friendship), method: :patch, class: "flex-1 bg-form-green active:bg-green-600 text-white font-medium p-2 rounded-lg transition-colors place-content-center" do %>
-                    <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-                    </svg>
-                  <% end %>
-                </div>
-
-                <div class="col-span-1 place-self-center">
-                  <%= button_to friendship_path(friendship), method: :delete, class: "flex-1 bg-red-600 active:bg-red-800 text-white font-medium p-2 rounded-lg transition-colors place-content-center", data: { turbo_confirm: t("friendships.confirms.decline") } do %>
-                    <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  <% end %>
-                </div>
-              </div>
-
-              <!-- Actions -->
-              <div class="flex gap-2">
-
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-    </section>
-
-    <!-- Demandes envoyées (pending) -->
-    <section class="my-8">
-
-      <div id="header-sent-requests" class="grid grid-cols-6 gap-1 mb-4 items-center">
-        <div class="col-span-1 place-self-center">
-          <svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-secondary-text" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-          </svg>
-        </div>
-
-        <h2 class="text-xl col-span-4 text-white">
-          <%= t("friendships.titles.sent") %>
-        </h2>
-
-        <% if @sent_friendships.any? %>
-          <div class="col-span-1 place-self-center">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-linear-to-r from-amber-400 to-amber-600 text-white text-xs font-bold">
-              <%= @sent_friendships.count %>
-            </span>
-          </div>
-        <% end %>
-
-      </div>
-
-      <% if @sent_friendships.empty? %>
-        <div class="text-center py-8 text-secondary-text">
-          <p><%= t("friendships.empty.sent") %></p>
-        </div>
-
-      <% else %>
-        <div class="grid grid-cols-1 gap-4">
-          <% @sent_friendships.each do |friendship| %>
-            <div class="rounded-2xl bg-white/5 backdrop-blur-md shadow-xl p-4 hover:bg-white/10 transition-colors">
-              <div class="grid grid-cols-6 items-center gap-2">
-                <!-- Avatar -->
-                <div class="size-10 rounded-full shadow-lg col-span-1 place-self-center">
-                  <div class="w-full h-full rounded-full overflow-hidden bg-linear-to-r from-amber-400 to-amber-600 flex items-center justify-center">
-
-                    <% if friendship.receiver.avatar? %>
-                      <%= cl_image_tag friendship.receiver.avatar, class: "w-full h-full object-cover rounded-full" %>
-
-                    <% else %>
-                      <svg width="24" height="24" viewBox="0 0 0.6 0.6" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="text-white">
-                        <path d="M.44.06a.06.06 0 1 1-.12 0 .06.06 0 0 1 .12 0m0 .38a.04.04 0 1 0 0 .08.04.04 0 0 0 0-.08M.514.244.438.168A.02.02 0 0 0 .423.161H.14a.02.02 0 0 0 0 .04h.108L.12.452V.46a.02.02 0 0 0 .04.008L.2.4h.08L.203.57.2.58a.02.02 0 0 0 .04.008L.428.213l.058.059A.02.02 0 0 0 .514.244"/>
-                      </svg>
-                    <% end %>
-                  </div>
-                </div>
-
-                <!-- Infos -->
-                <ul class="col-span-4">
-                  <%= link_to user_path(friendship.receiver) do %>
-                    <li class="font-semibold text-white"><%= friendship.receiver.first_name %></li>
-                    <li class="text-secondary-text text-sm">@<%= friendship.receiver.username %></li>
-                  <% end %>
-                </ul>
-
-                <div class="col-span-1 place-self-center">
-                  <%= button_to friendship_path(friendship), method: :delete, class: "flex-1 bg-gray-600 active:bg-gray-800 text-white font-medium p-2 rounded-lg transition-colors place-content-center", data: { turbo_confirm: t("friendships.confirms.cancel") } do %>
-                    <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  <% end %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-    </section>
-
-    <!-- Amis acceptés -->
-    <section class="my-8">
-
-      <div id="header-accepted-friends" class="grid grid-cols-6 gap-1 mb-4 items-center">
-        <div class="col-span-1 place-self-center">
-          <svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-secondary-text" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-          </svg>
-        </div>
-
-        <h2 class="text-xl col-span-4 text-white">
-          <%= t("friendships.titles.friends") %>
-        </h2>
-
-        <% if @accepted_friendships.any? %>
-          <div class="col-span-1 place-self-center">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-linear-to-r from-amber-400 to-amber-600 text-white text-xs font-bold">
-              <%= @accepted_friendships.count %>
-            </span>
-          </div>
-        <% end %>
-
-      </div>
-
-      <% if @accepted_friendships.empty? %>
-        <div class="text-center py-12 text-secondary-text">
-          <p class="text-lg"><%= t("friendships.empty.friends") %></p>
-          <p class="text-sm mt-2"><%= t("friendships.empty.friends_hint") %></p>
-        </div>
-
-      <% else %>
-        <div class="grid grid-cols-1 gap-4">
-          <% @accepted_friendships.each do |friendship| %>
-            <% friend = friendship.sender == current_user ? friendship.receiver : friendship.sender %>
-            <div class="rounded-2xl bg-white/5 backdrop-blur-md shadow-xl p-4 hover:bg-white/10 transition-colors">
-              <div class="grid grid-cols-6 items-center gap-2">
-                <!-- Avatar -->
-                <div class="size-10 rounded-full shadow-lg col-span-1 place-self-center">
-                  <div class="w-full h-full rounded-full overflow-hidden bg-linear-to-r from-amber-400 to-amber-600 flex items-center justify-center">
-
-                    <% if friend.avatar? %>
-                      <%= cl_image_tag friend.avatar, class: "w-full h-full object-cover rounded-full" %>
-
-                    <% else %>
-                      <svg width="24" height="24" viewBox="0 0 0.6 0.6" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="text-white">
-                        <path d="M.44.06a.06.06 0 1 1-.12 0 .06.06 0 0 1 .12 0m0 .38a.04.04 0 1 0 0 .08.04.04 0 0 0 0-.08M.514.244.438.168A.02.02 0 0 0 .423.161H.14a.02.02 0 0 0 0 .04h.108L.12.452V.46a.02.02 0 0 0 .04.008L.2.4h.08L.203.57.2.58a.02.02 0 0 0 .04.008L.428.213l.058.059A.02.02 0 0 0 .514.244"/>
-                      </svg>
-                    <% end %>
-                  </div>
-                </div>
-
-                <!-- Infos -->
-                <ul class="col-span-3">
-                  <%= link_to user_path(friend) do %>
-                    <li class="font-semibold text-white"><%= friend.first_name %></li>
-                    <li class="text-secondary-text text-sm">@<%= friend.username %></li>
-                  <% end %>
-                </ul>
-
-                <div class="col-span-1 place-self-center">
-                  <%= link_to user_path(friend), class: "block flex-1 bg-primary-yellow active:bg-yellow-600 text-white font-medium p-2 rounded-lg transition-colors place-content-center" do %>
-                    <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                    </svg>
-                  <% end %>
-                </div>
-
-                <div class="col-span-1 place-self-center">
-                  <%= button_to friendship_path(friendship), method: :delete, class: "flex-1 bg-red-600 active:bg-red-800 text-white font-medium p-2 rounded-lg transition-colors place-content-center", data: { turbo_confirm: t("friendships.confirms.remove", name: friend.first_name) } do %>
-                    <svg xmlns="http://www.w3.org/2000/svg" class="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                    </svg>
-                  <% end %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-    </section>
+    <% case @tab %>
+    <% when "received" %>
+      <%= render "friendships/components/section_received", friendships: @received_friendships %>
+    <% when "sent" %>
+      <%= render "friendships/components/section_sent", friendships: @sent_friendships %>
+    <% when "declined" %>
+      <%= render "friendships/components/section_declined", friendships: @declined_friendships %>
+    <% else %>
+      <%= render "friendships/components/section_friends", friendships: @accepted_friendships, current_user: current_user %>
+    <% end %>
   </div>
 </main>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -57,7 +57,7 @@
         <% end %>
 
     <%# ou je peux refuser %>
-        <%= link_to friendship_path(@friendship), class: "inline-flex items-center gap-2 px-6 py-3 rounded-full bg-red-600 text-white font-bold shadow-lg hover:bg-red-700 transition-all duration-200", data: { turbo_method: :delete, turbo_confirm: t("users.confirms.decline") } do %>
+        <%= button_to friendship_path(@friendship), method: :patch, params: { status: "declined" }, class: "inline-flex items-center gap-2 px-6 py-3 rounded-full bg-red-600 text-white font-bold shadow-lg hover:bg-red-700 transition-all duration-200", data: { turbo_confirm: t("users.confirms.decline") } do %>
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -84,6 +84,17 @@
           <%= t("users.actions.remove_friend") %>
         <% end %>
 
+<%# Receiver only: declined request %>
+      <% elsif @friendship.status == "declined" && @friendship.receiver == current_user %>
+        <p class="text-secondary-text mb-4"><%= t("users.labels.declined_by_you") %></p>
+        <%= button_to friendship_path(@friendship), method: :delete, class: "inline-flex items-center gap-2 px-6 py-3 rounded-full bg-gray-700 text-white font-bold shadow-lg hover:bg-gray-600 transition-all duration-200", data: { turbo_confirm: t("users.confirms.remove_declined") } do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+          <%= t("users.actions.remove_declined") %>
+        <% end %>
+
+<%# Sender: declined — nothing shown %>
       <% end %>
     </section>
 

--- a/config/locales/en/friendship.yml
+++ b/config/locales/en/friendship.yml
@@ -5,6 +5,7 @@ en:
       search: "Find friends"
       received: "Received requests"
       sent: "Sent requests"
+      declined: "Declined requests"
       friends: "My friends"
       results: "Search results"
     flash:
@@ -13,9 +14,10 @@ en:
         failure: "Could not send the friend request."
       update:
         success: "You are now friends with %{name}."
-        failure: "Could not accept the friend request."
-      destroy:
         declined: "Friend request declined."
+        failure: "Could not update this friendship."
+      destroy:
+        removed_declined: "Declined request removed. They can send you a new request."
         unfriended: "You are no longer friends with %{name}."
         cancelled: "Friend request cancelled."
         unauthorized: "Action not authorized."
@@ -26,11 +28,13 @@ en:
       decline: "Decline"
       cancel_request: "Cancel"
       remove: "Remove"
+      remove_declined: "Remove"
       add: "Add"
     confirms:
       decline: "Decline this friend request?"
       cancel: "Cancel this friend request?"
       remove: "Remove %{name} from your friends?"
+      remove_declined: "Remove this declined request so they can ask again?"
     empty:
       received: "No friend requests received"
       sent: "No friend requests sent"
@@ -40,9 +44,12 @@ en:
       search_results: "No users found for this search"
     labels:
       search_field: "Search for a player"
+      declined_by_you: "You declined their friend request"
+
     placeholders:
       search: "Search for a player..."
     aria:
+      tabs: "Friendship categories"
       back: "Back to friends"
       search_field: "Search for a player"
       search_submit: "Search"

--- a/config/locales/en/user.yml
+++ b/config/locales/en/user.yml
@@ -9,16 +9,19 @@ en:
       decline_request: "Decline request"
       cancel_request: "Cancel request"
       remove_friend: "Remove from friends"
+      remove_declined: "Remove declined request"
     confirms:
       decline: "Are you sure you want to decline this friend request?"
       cancel: "Are you sure you want to cancel your friend request?"
       remove: "Are you sure you want to remove this user from your friends?"
+      remove_declined: "Remove this declined request so they can ask again?"
     labels:
       email: "Email"
       role: "Role"
       role_player: "Player"
       role_admin: "Admin"
       member_since: "Member since"
+      declined_by_you: "You declined their friend request"
   activerecord:
     errors:
       models:

--- a/config/locales/fr/friendship.yml
+++ b/config/locales/fr/friendship.yml
@@ -5,6 +5,7 @@ fr:
       search: "Rechercher des amis"
       received: "Demandes reçues"
       sent: "Demandes envoyées"
+      declined: "Demandes refusées"
       friends: "Mes amis"
       results: "Résultats de recherche"
     flash:
@@ -13,9 +14,10 @@ fr:
         failure: "Impossible d'envoyer la demande d'amitié."
       update:
         success: "Vous êtes maintenant amis avec %{name}."
-        failure: "Impossible d'accepter la demande d'amitié."
-      destroy:
         declined: "Demande d'amitié refusée."
+        failure: "Impossible de mettre à jour cette demande d'amitié."
+      destroy:
+        removed_declined: "Demande refusée supprimée. Cette personne pourra vous renvoyer une demande."
         unfriended: "Vous n'êtes plus ami avec %{name}."
         cancelled: "Demande d'amitié annulée."
         unauthorized: "Action non autorisée."
@@ -26,11 +28,13 @@ fr:
       decline: "Refuser"
       cancel_request: "Annuler"
       remove: "Supprimer"
+      remove_declined: "Supprimer"
       add: "Ajouter"
     confirms:
       decline: "Refuser cette demande d'amitié ?"
       cancel: "Annuler cette demande d'amitié ?"
       remove: "Supprimer %{name} de vos amis ?"
+      remove_declined: "Supprimer ce refus pour qu'une nouvelle demande soit possible ?"
     empty:
       received: "Aucune demande d'amitié reçue"
       sent: "Aucune demande d'amitié envoyée"
@@ -40,9 +44,12 @@ fr:
       search_results: "Aucun utilisateur trouvé pour cette recherche"
     labels:
       search_field: "Rechercher un joueur"
+      declined_by_you: "Vous avez refusé sa demande d'amis"
+
     placeholders:
       search: "Rechercher un joueur..."
     aria:
+      tabs: "Catégories d'amitié"
       back: "Retour aux amis"
       search_field: "Rechercher un joueur"
       search_submit: "Lancer la recherche"

--- a/config/locales/fr/user.yml
+++ b/config/locales/fr/user.yml
@@ -9,16 +9,19 @@ fr:
       decline_request: "Refuser la demande"
       cancel_request: "Annuler la demande"
       remove_friend: "Supprimer de mes amis"
+      remove_declined: "Supprimer ce refus"
     confirms:
       decline: "Es-tu sûr de vouloir refuser cette demande d'ami ?"
       cancel: "Es-tu sûr de vouloir annuler ta demande d'ami ?"
       remove: "Es-tu sûr de vouloir supprimer cet utilisateur de tes amis ?"
+      remove_declined: "Supprimer ce refus pour qu'une nouvelle demande soit possible ?"
     labels:
       email: "Email"
       role: "Rôle"
       role_player: "Joueur"
       role_admin: "Admin"
       member_since: "Membre depuis"
+      declined_by_you: "Vous avez refusé sa demande d'amis"
   activerecord:
     errors:
       models:

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -84,16 +84,19 @@ Both paths create the same `Friendship` record (`sender` = current `User`, `rece
 | Action | Who | Result |
 |--------|-----|--------|
 | Send request | `sender` | `Friendship` with `status: pending`; **`friendship_requested` `Notification` to `receiver`** (hidden from inbox — see Notification) |
-| Accept | `receiver` | `status` → `accepted` |
-| Refuse | `receiver` | `Friendship` destroyed |
+| Accept | `receiver` (pending only) | `status` → `accepted` |
+| Decline | `receiver` (pending only) | `status` → `declined`; `friendship_requested` `Notification` removed |
 | Cancel request | `sender` (pending) | `Friendship` destroyed |
 | Unfriend | `sender` or `receiver` (accepted) | `Friendship` destroyed |
+| Remove declined | `receiver` (declined only) | `Friendship` destroyed — either party may then send a new request |
+
+`accept` and `decline` only apply from `pending`. A `declined` `Friendship` cannot become `accepted` without destroy + a new request.
 
 ### States
 
-- **pending** — request sent; `receiver` can accept or refuse.
+- **pending** — request sent; `receiver` can accept or decline.
 - **accepted** — friends; enables private `Event` visibility and `Event` invitations.
-- **declined** — allowed by model validation; **not used** in the web flow (refuse destroys the record). Remove or repurpose in a future cleanup if unused.
+- **declined** — soft reject. Visible **only to the `receiver`**. The `sender` sees no declined UI (soft-ghosted: pending sent disappears). Blocks search and reverse requests until the `receiver` removes it.
 
 ### Validation rules
 
@@ -108,11 +111,17 @@ Both paths create the same `Friendship` record (`sender` = current `User`, `rece
 - `has_pending_request_from?(other_user)` — other `User` is `sender`, `status: pending`.
 - `has_asked_to_be_friend_with?(other_user)` — current `User` is `sender`, `status: pending`.
 - `accepted_friendships` — all accepted `Friendship` records involving the `User`.
+- `declined_received_friendships` — declined `Friendship` records where the `User` is `receiver`.
 - `get_my_friends_but_not_participants(event)` — accepted friends not yet on the `Event` (invite picker).
 
 ### Index
 
-`FriendshipsController#index` lists accepted friends, pending sent requests, and pending received requests for the current `User`.
+`FriendshipsController#index` lists accepted friends, pending sent requests, pending received requests, and **declined received** requests (receiver only) for the current `User`.
+
+### Profile (`users#show`)
+
+- **Declined, current `User` is `receiver`:** label that they declined the request + action to remove the declined `Friendship`.
+- **Declined, current `User` is `sender`:** no friendship CTA (nothing shown).
 
 ---
 
@@ -129,7 +138,7 @@ A football match scheduled by a `User`. The organizer is always `event.user` (`b
 | `price` | ≥ 0; whole euros only (step `1.00`); always displayed with 2 decimal places |
 | `is_private` | Boolean; **defaults to `true`** |
 | `description` | Optional |
-| `latitude`, `longitude` | Optional; no model validation today |
+| `latitude`, `longitude` | Required (set via Places autocomplete on web; needed for the future JSON API / map features). Model presence validation still missing — form HTML `required` only today |
 
 ### Official headcount (`Event#participants_count`)
 
@@ -366,7 +375,7 @@ Participation includes `bench` for `updated` and `canceled`. `joined` / `left` a
 - `notifiable` = `Friendship`; recipient = `receiver`.
 - `payload` includes sender identity (`first_name`, etc.).
 - **Not shown** in the notifications inbox or unread badge. Players act on requests via `/friendships` (red badge on friends link).
-- Destroyed when the `Friendship` is accepted or destroyed (refuse / cancel).
+- Destroyed when the `Friendship` is accepted, declined, or destroyed (cancel / unfriend / remove declined).
 
 ### `joined`
 
@@ -485,6 +494,7 @@ See [TESTING.md](TESTING.md) — feature workflow is: clarify → domain → mig
 | `EventParticipant` `joined` / `left` keyed on `slot` via `countable_teams` | **Implemented** |
 | `Event` validation messages | **Implemented** — I18n (`config/locales/<locale>/event.yml`) |
 | `Event` create/update strong params include `latitude` / `longitude` | **Implemented** |
+| `Event` `latitude` / `longitude` presence (model + I18n) | **Not implemented** — HTML `required` on form only; columns still nullable in schema |
 | `Notification` on pending `Friendship` (`friendship_requested`) | **Implemented** — hidden from inbox; friends badge UX |
 | Push delivery (APNs / FCM) | **Not implemented** — web inbox first; SolidQueue later |
 | `reminder` `Notification` kind | Enum reserved; **no behavior** until SolidQueue |
@@ -492,4 +502,4 @@ See [TESTING.md](TESTING.md) — feature workflow is: clarify → domain → mig
 | Admin stats dashboard | **Later** — out of MVP admin CRUD pass |
 | JSON API | **Not implemented** |
 | Google OAuth remnants (`users.tokens`, etc.) | **To remove** — email auth only |
-| `Friendship#decline` / `status: declined` | Model supports it; web flow destroys on refuse instead |
+| `Friendship#decline` / `status: declined` | **Implemented** — receiver-only visibility; remove declined to allow re-request |

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -29,7 +29,31 @@ RSpec.describe Friendship, type: :model do
   describe "CRUD" do
     it "accepts a pending friendship" do
       friendship = create(:friendship, status: "pending")
-      friendship.accept
+      expect(friendship.accept).to be(true)
+      expect(friendship.reload.status).to eq("accepted")
+    end
+
+    it "declines a pending friendship without destroying it" do
+      friendship = create(:friendship, status: "pending")
+
+      expect {
+        expect(friendship.decline).to be(true)
+      }.not_to change(Friendship, :count)
+
+      expect(friendship.reload.status).to eq("declined")
+    end
+
+    it "does not accept a declined friendship" do
+      friendship = create(:friendship, status: "declined")
+
+      expect(friendship.accept).to be(false)
+      expect(friendship.reload.status).to eq("declined")
+    end
+
+    it "does not decline an accepted friendship" do
+      friendship = create(:friendship, status: "accepted")
+
+      expect(friendship.decline).to be(false)
       expect(friendship.reload.status).to eq("accepted")
     end
   end
@@ -61,6 +85,15 @@ RSpec.describe Friendship, type: :model do
 
       expect {
         friendship.accept
+      }.to change { receiver.notifications.friendship_requested.count }.from(1).to(0)
+    end
+
+    it "removes the notification when the friendship is declined" do
+      friendship = create(:friendship, status: "pending")
+      receiver = friendship.receiver
+
+      expect {
+        friendship.decline
       }.to change { receiver.notifications.friendship_requested.count }.from(1).to(0)
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -96,7 +96,10 @@ RSpec.describe User, type: :model do
       stranger = create(:user)
       create(:friendship, sender: current_user, receiver: friend, status: "declined")
 
-      expect(described_class.users_without_friendship(current_user)).to contain_exactly(stranger)
+      results = described_class.users_without_friendship(current_user)
+
+      expect(results).to include(stranger)
+      expect(results).not_to include(friend, current_user)
     end
   end
 
@@ -180,6 +183,16 @@ RSpec.describe User, type: :model do
       accepted_friendship = create(:friendship, sender: user, receiver: accepted_receiver, status: "accepted")
 
       expect(user.accepted_sent_friendships).to contain_exactly(accepted_friendship)
+    end
+
+    it "keeps declined received friendships scoped to the receiver" do
+      receiver = create(:user)
+      sender = create(:user)
+      other = create(:user)
+      declined = create(:friendship, sender: sender, receiver: receiver, status: "declined")
+      create(:friendship, sender: receiver, receiver: other, status: "declined")
+
+      expect(receiver.declined_received_friendships).to contain_exactly(declined)
     end
   end
 

--- a/spec/requests/friendships_spec.rb
+++ b/spec/requests/friendships_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "Friendships", type: :request do
+  describe "PATCH /friendships/:id" do
+    it "lets the receiver decline a pending friendship" do
+      friendship = create(:friendship, status: "pending")
+      sign_in friendship.receiver
+
+      expect {
+        patch friendship_path(friendship), params: { status: "declined" }
+      }.to change { friendship.reload.status }.from("pending").to("declined")
+        .and change { friendship.receiver.notifications.friendship_requested.count }.from(1).to(0)
+    end
+
+    it "rejects decline from the sender" do
+      friendship = create(:friendship, status: "pending")
+      sign_in friendship.sender
+
+      expect {
+        patch friendship_path(friendship), params: { status: "declined" }
+      }.not_to change { friendship.reload.status }
+    end
+
+    it "rejects accepting a declined friendship" do
+      friendship = create(:friendship, status: "declined")
+      sign_in friendship.receiver
+
+      expect {
+        patch friendship_path(friendship)
+      }.not_to change { friendship.reload.status }
+    end
+  end
+
+  describe "DELETE /friendships/:id" do
+    it "lets the receiver destroy a declined friendship" do
+      friendship = create(:friendship, status: "declined")
+      sign_in friendship.receiver
+
+      expect {
+        delete friendship_path(friendship)
+      }.to change(Friendship, :count).by(-1)
+    end
+
+    it "rejects destroy of a declined friendship by the sender" do
+      friendship = create(:friendship, status: "declined")
+      sign_in friendship.sender
+
+      expect {
+        delete friendship_path(friendship)
+      }.not_to change(Friendship, :count)
+    end
+
+    it "no longer destroys a pending friendship when the receiver deletes" do
+      friendship = create(:friendship, status: "pending")
+      sign_in friendship.receiver
+
+      expect {
+        delete friendship_path(friendship)
+      }.not_to change(Friendship, :count)
+
+      expect(friendship.reload.status).to eq("pending")
+    end
+  end
+end


### PR DESCRIPTION
- Added support for declining friendship requests, allowing users to decline pending requests without destroying the Friendship record.
- Introduced a new `declined` status for friendships, enabling users to view and manage declined requests.
- Updated the Friendship model to include a `declined` scope and methods for accepting and declining friendships.
- Enhanced the FriendshipsController to handle declined requests in the index action and provide appropriate redirects and flash messages.
- Refactored views to display declined friendships and added new components for rendering declined requests.
- Updated tests to cover the new functionality for declining friendships and ensure proper behavior in various scenarios.