### PR TITLE
Implement bench reminder functionality for events

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -42,7 +42,13 @@ module NotificationsHelper
         author: notification.payload["author"]
       )
     when "reminder"
-      t("notifications.messages.reminder", title: notification.payload["title"])
+      t(
+        "notifications.messages.reminder",
+        count: notification.payload["spots_remaining"].to_i,
+        title: notification.payload["title"],
+        author: notification.payload["author"],
+        start_time: human_future_date(notification.payload["start_time"])
+      )
     when "friendship_requested"
       t(
         "notifications.messages.friendship_requested",

--- a/app/jobs/events/bench_reminder_job.rb
+++ b/app/jobs/events/bench_reminder_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Events::BenchReminderJob < ApplicationJob
+  queue_as :default
+
+  discard_on ActiveJob::DeserializationError
+
+  def perform(event_id:, expected_start_time:)
+    event = Event.find_by(id: event_id)
+    return if event.nil?
+    return if event.start_time.iso8601 != expected_start_time
+
+    event.notify_bench_reminder!
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   include Event::Notifications
+  include Event::BenchReminder
 
   TEAM_SLOTS = %w[team_one team_two bench].freeze
   SLOT_DEFAULT_LABEL_KEYS = TEAM_SLOTS.index_with { |slot| "event_team.slots.#{slot}.default_label" }.freeze
@@ -73,6 +74,18 @@ class Event < ApplicationRecord
     event_participants.count
   end
 
+  def spots_remaining
+    [ number_of_participants - participants_count, 0 ].max
+  end
+
+  def bench_user_ids
+    event_participants.joins(:event_team).merge(EventTeam.bench).pluck(:user_id)
+  end
+
+  def reminder_due_at
+    start_time - 24.hours
+  end
+
   def countable_slots_full?
     participants_count >= number_of_participants
   end
@@ -130,8 +143,7 @@ class Event < ApplicationRecord
   end
 
   def price_must_be_whole_euro
-    return if price.blank?
-    return if price.to_d == price.to_d.round(0)
+    return if price.blank? || price.to_d == price.to_d.round(0)
 
     errors.add(:price, :not_whole_euro)
   end

--- a/app/models/event/bench_reminder.rb
+++ b/app/models/event/bench_reminder.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Event::BenchReminder
+  extend ActiveSupport::Concern
+
+  included do
+    after_create_commit :schedule_bench_reminder!
+    after_update_commit :reschedule_bench_reminder_if_start_time_changed
+    before_destroy :discard_bench_reminder_job!, prepend: true
+  end
+
+  def schedule_bench_reminder!
+    discard_bench_reminder_job!
+
+    job = Events::BenchReminderJob
+      .set(wait_until: [ reminder_due_at, Time.current ].max)
+      .perform_later(event_id: id, expected_start_time: start_time.iso8601)
+
+    update_column(:bench_reminder_job_id, job.job_id)
+  end
+
+  def notify_bench_reminder!
+    discard_bench_reminder_job!
+    return if spots_remaining <= 0
+
+    ids = bench_user_ids
+    return if ids.empty?
+    return if reminder_already_sent_for_current_start_time?
+
+    Notification.deliver_many!(
+      user_ids: ids,
+      kind: :reminder,
+      notifiable: self,
+      payload: {
+        title: title,
+        author: user.first_name,
+        start_time: start_time,
+        spots_remaining: spots_remaining
+      }
+    )
+  end
+
+  def discard_bench_reminder_job!
+    job_id = bench_reminder_job_id
+    return if job_id.blank?
+
+    clear_bench_reminder_job_id!
+    discard_active_job(job_id)
+  end
+
+  private
+
+  def reschedule_bench_reminder_if_start_time_changed
+    return unless saved_change_to_start_time?
+
+    schedule_bench_reminder!
+  end
+
+  def clear_bench_reminder_job_id!
+    return if bench_reminder_job_id.blank?
+    return unless self.class.exists?(id)
+
+    update_column(:bench_reminder_job_id, nil)
+  end
+
+  def discard_active_job(job_id)
+    if defined?(SolidQueue::Job)
+      solid_job = SolidQueue::Job.find_by(active_job_id: job_id)
+      return solid_job.discard if solid_job
+    end
+
+    adapter = ActiveJob::Base.queue_adapter
+    return unless adapter.respond_to?(:enqueued_jobs)
+
+    adapter.enqueued_jobs.reject! { |job| job["job_id"] == job_id }
+  end
+
+  def reminder_already_sent_for_current_start_time?
+    notifications.reminder.where("payload->>'start_time' = ?", start_time.iso8601).exists?
+  end
+end

--- a/app/models/event_participant/notifications.rb
+++ b/app/models/event_participant/notifications.rb
@@ -33,7 +33,7 @@ module EventParticipant::Notifications
   private
 
   def deliver_notifications(kind)
-    recipient_ids = team_notification_recipients.pluck(:id)
+    recipient_ids = team_notification_recipients(kind).pluck(:id)
     return if recipient_ids.empty?
 
     Notification.deliver_many!(
@@ -48,11 +48,13 @@ module EventParticipant::Notifications
     )
   end
 
-  def team_notification_recipients
+  def team_notification_recipients(kind)
+    slots = kind.to_sym == :left ? %w[team_one team_two bench] : EventTeam::COUNTABLE_SLOTS
+
     User.where(
       id: event.event_participants
         .joins(:event_team)
-        .merge(EventTeam.countable_teams)
+        .where(event_teams: { slot: slots })
         .where.not(user_id: user_id)
         .select(:user_id)
     )

--- a/config/locales/en/notification.yml
+++ b/config/locales/en/notification.yml
@@ -19,7 +19,9 @@ en:
       left: "%{player} left your event \"%{title}\"."
       invited: "%{sender} invited you to the event \"%{title}\" scheduled for %{start_time}."
       canceled: "The event \"%{title}\" scheduled for %{start_time} and organized by %{author} was canceled."
-      reminder: "Reminder: \"%{title}\" is coming up."
+      reminder:
+        one: "There is still %{count} spot left in the event \"%{title}\" by %{author}, for %{start_time}."
+        other: "There are still %{count} spots left in the event \"%{title}\" by %{author}, for %{start_time}."
       friendship_requested: "%{first_name} sent you a friend request."
       default: "You have a new notification."
       updated:

--- a/config/locales/fr/notification.yml
+++ b/config/locales/fr/notification.yml
@@ -19,7 +19,9 @@ fr:
       left: "%{player} a quitté ton événement \"%{title}\"."
       invited: "%{sender} t'a invité à l'événement \"%{title}\" prévu %{start_time}."
       canceled: "L'événement \"%{title}\" prévu %{start_time} et organisé par %{author} a été annulé."
-      reminder: "Rappel : \"%{title}\" approche."
+      reminder:
+        one: "Il reste toujours %{count} place dans l'événement \"%{title}\" par %{author}, pour %{start_time}."
+        other: "Il reste toujours %{count} places dans l'événement \"%{title}\" par %{author}, pour %{start_time}."
       friendship_requested: "%{first_name} vous a envoyé une demande d'amitié."
       default: "Vous avez une nouvelle notification."
       updated:

--- a/db/migrate/20260721080000_add_bench_reminder_job_id_to_events.rb
+++ b/db/migrate/20260721080000_add_bench_reminder_job_id_to_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBenchReminderJobIdToEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :events, :bench_reminder_job_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_21_010000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_21_080000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -49,6 +49,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_21_010000) do
     t.datetime "updated_at", null: false
     t.decimal "latitude", precision: 10, scale: 6
     t.decimal "longitude", precision: 10, scale: 6
+    t.string "bench_reminder_job_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -359,7 +359,11 @@ end
     notifiable: event,
     kind: :reminder,
     read: false,
-    payload: notification_payload_for(event),
+    payload: notification_payload_for(
+      event,
+      author: event.user.first_name,
+      spots_remaining: event.spots_remaining
+    ),
     created_at: (6 - index).hours.ago
   )
 end

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -285,6 +285,7 @@ Same rules as private access above; for public `Event` records, any authenticate
 - One `EventParticipant` per `User` per `Event`.
 - `User` selects an `EventTeam` (`event_team_id`) by `slot`: `team_one`, `team_two`, or `bench`.
 - Joining `team_one` or `team_two` emits `joined` `Notification` records for other countable-squad `User` records. Joining `bench` does not.
+- Leaving `team_one` or `team_two` (or moving countable → bench) emits `left` for other countable-squad **and bench** `User` records (excluding the actor). `joined` recipients stay countable-only.
 - Creating an `EventParticipant` **destroys** that `User`'s `Invitation` for the `Event` (if any). The inbox `Notification.invited` is kept (history).
 - **Capacity:** `number_of_participants` caps the total on **countable** teams (`participants_count`). When full, new joins to countable teams are rejected; **bench** remains available.
 - **Per-team cap:** `Event#countable_slots_for(team)` — `team_one` gets `number_of_participants / 2` (floor), `team_two` gets `(number_of_participants + 1) / 2` (ceil). Example: capacity `11` → `5` + `6`. `EventTeam#full?` when at cap; join button hidden when `!joinable?` (`bench` is always joinable).
@@ -305,7 +306,7 @@ Emit `joined` / `left` only for these transitions:
 ### Leave
 
 - `User` destroys their own `EventParticipant`.
-- Leaving `team_one` or `team_two` emits `left` `Notification` records. Leaving `bench` does not.
+- Leaving `team_one` or `team_two` emits `left` `Notification` records for remaining countable **and bench** participants. Leaving `bench` does not.
 - After leave, if `event.viewable_by?(user)` is false, redirect away from the `Event` page.
 
 ---
@@ -373,11 +374,12 @@ A `User` receives a `Notification` when:
 | Pending `Friendship` request | `friendship_requested` | `Friendship` | `receiver` | **Hidden** — UX is the friends badge (`pending_received_friendships`) |
 | Invited to an `Event` | `invited` | `Event` | invited `User` | Shown |
 | Joins `EventTeam` `team_one` or `team_two` | `joined` | `Event` | other `User` records on official squads | Shown |
-| Leaves `EventTeam` `team_one` or `team_two` | `left` | `Event` | other `User` records on official squads | Shown |
+| Leaves `EventTeam` `team_one` or `team_two` | `left` | `Event` | other countable **and bench** `User` records | Shown |
 | Tracked `Event` field changes | `updated` | `Event` | each `EventParticipant` `User` except `event.user` | Shown |
 | `Event` destroyed | `canceled` | `nil` | each `EventParticipant` `User` except `event.user` | Shown |
+| ~24h before `start_time` with open countable spots | `reminder` | `Event` | current bench `User` records | Shown |
 
-Participation includes `bench` for `updated` and `canceled`. `joined` / `left` apply only to `team_one` and `team_two`, not `bench`.
+Participation includes `bench` for `updated`, `canceled`, and as **recipients** of `left` / `reminder`. Emitting `joined` / `left` still keys off countable-team transitions only (not joining/leaving the bench itself).
 
 `Notification.inbox` excludes `friendship_requested`. Header unread badge uses `notifications.inbox.unread`.
 
@@ -417,13 +419,21 @@ Participation includes `bench` for `updated` and `canceled`. `joined` / `left` a
 
 ### `left`
 
-- Created when a `User` destroys an `EventParticipant` on `slot` `team_one` or `team_two`.
-- Not created for `bench`.
-- Recipients: remaining `User` records on official squads.
+- Created when a `User` destroys an `EventParticipant` on `slot` `team_one` or `team_two`, or moves countable → bench.
+- Not created when leaving the bench itself.
+- Recipients: remaining `User` records on official squads **and** the bench (excluding the actor). This is how bench players learn a countable spot opened after a silent T−24h reminder — not a second `reminder`.
+
+### `reminder`
+
+- Scheduled by `Event` on create and whenever `start_time` changes: `Events::BenchReminderJob` at `max(start_time - 24.hours, Time.current)`.
+- `events.bench_reminder_job_id` stores the Active Job id; previous job is **discarded** on reschedule and on `Event` destroy.
+- At perform time: no-op if event missing, `start_time` ≠ enqueued expectation, `spots_remaining == 0`, or bench empty; otherwise `deliver_many!` to current bench users.
+- Idempotent per `(event, start_time)` — a reminder already sent for that start does not send again; a **new** `start_time` schedules a new cycle even if an older reminder exists.
+- `payload`: `title`, `author` (`event.user.first_name`), `start_time`, `spots_remaining`.
+- Not a retry when spots open after a silent T−24h run (`left` covers that). Users who join the bench after the fire do not get a late reminder.
 
 ### Reserved enum values
 
-- `reminder` — reserved for phase 2 (SolidQueue scheduled reminders). No producer yet.
 - `created` — **removed** (unused).
 
 ### Read state & navigation
@@ -536,7 +546,8 @@ See [TESTING.md](TESTING.md) — feature workflow is: clarify → domain → mig
 | `Notification` on pending `Friendship` (`friendship_requested`) | **Implemented** — hidden from inbox; friends badge UX |
 | Push delivery (APNs / FCM) | **Not implemented** — web inbox + live toast first; Solid Queue later for push |
 | Solid Queue + Solid Cable | **Implemented** — notification jobs, Devise mail via Active Job, live toasts |
-| `reminder` `Notification` kind | Enum reserved; **no behavior** until scheduled jobs phase |
+| `reminder` `Notification` kind | **Implemented** — Solid Queue delayed job; `events.bench_reminder_job_id` for discard |
+| `left` recipients include bench | **Implemented** — countable leave / countable→bench |
 | `created` `Notification` kind | **Removed** |
 | Admin stats dashboard | **Later** — out of MVP admin CRUD pass |
 | JSON API | **Not implemented** |

--- a/spec/models/event_bench_reminder_spec.rb
+++ b/spec/models/event_bench_reminder_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Event, "bench reminder", type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
+  def team_slot(event, slot)
+    event.event_teams.find_by!(slot: slot)
+  end
+
+  describe "#spots_remaining" do
+    it "returns open countable slots" do
+      event = create(:event, number_of_participants: 4)
+      create(:event_participant, user: create(:user), event: event, event_team: team_slot(event, "team_two"))
+
+      expect(event.spots_remaining).to eq(2)
+    end
+  end
+
+  describe "scheduling" do
+    it "enqueues a bench reminder job 24h before start_time on create" do
+      freeze_time do
+        start_time = 3.days.from_now
+
+        expect {
+          create(:event, start_time: start_time)
+        }.to have_enqueued_job(Events::BenchReminderJob)
+          .with(hash_including(expected_start_time: start_time.iso8601))
+          .at(start_time - 24.hours)
+      end
+    end
+
+    it "enqueues immediately when start_time is less than 24h away" do
+      freeze_time do
+        start_time = 12.hours.from_now
+
+        expect {
+          create(:event, start_time: start_time)
+        }.to have_enqueued_job(Events::BenchReminderJob).at(Time.current)
+      end
+    end
+
+    it "discards the previous job and reschedules when start_time changes" do
+      freeze_time do
+        event = create(:event, start_time: 3.days.from_now)
+        old_job_id = event.reload.bench_reminder_job_id
+        new_start = 5.days.from_now
+
+        expect {
+          event.update!(start_time: new_start)
+        }.to have_enqueued_job(Events::BenchReminderJob)
+          .with(hash_including(expected_start_time: new_start.iso8601))
+          .at(new_start - 24.hours)
+
+        expect(event.reload.bench_reminder_job_id).to be_present
+        expect(event.bench_reminder_job_id).not_to eq(old_job_id)
+        expect(enqueued_jobs.count { |job| job["job_id"] == old_job_id }).to eq(0)
+      end
+    end
+
+    it "discards the pending reminder job when the event is destroyed" do
+      event = create(:event, start_time: 3.days.from_now)
+      job_id = event.reload.bench_reminder_job_id
+
+      event.destroy!
+
+      expect(enqueued_jobs.count { |job| job["job_id"] == job_id }).to eq(0)
+    end
+  end
+
+  describe "#notify_bench_reminder!", :notification_jobs do
+    it "delivers a reminder to every bench user when spots remain" do
+      event = create(:event, number_of_participants: 4, start_time: 2.days.from_now)
+      bench_a = create(:user)
+      bench_b = create(:user)
+      create(:event_participant, user: bench_a, event: event, event_team: team_slot(event, "bench"))
+      create(:event_participant, user: bench_b, event: event, event_team: team_slot(event, "bench"))
+
+      expect {
+        event.notify_bench_reminder!
+      }.to change { bench_a.notifications.reminder.count }.by(1)
+        .and change { bench_b.notifications.reminder.count }.by(1)
+
+      notification = bench_a.notifications.reminder.last
+      expect(notification.notifiable).to eq(event)
+      expect(notification.payload).to include(
+        "title" => event.title,
+        "author" => event.user.first_name,
+        "spots_remaining" => event.spots_remaining
+      )
+      expect(notification.payload["start_time"]).to eq(event.start_time.iso8601)
+    end
+
+    it "sends nothing when countable slots are full" do
+      event = create(:event, number_of_participants: 2, start_time: 2.days.from_now)
+      create(:event_participant, user: create(:user), event: event, event_team: team_slot(event, "team_two"))
+      bench_player = create(:user)
+      create(:event_participant, user: bench_player, event: event, event_team: team_slot(event, "bench"))
+
+      expect {
+        event.notify_bench_reminder!
+      }.not_to change { Notification.where(kind: :reminder).count }
+    end
+
+    it "sends nothing when the bench is empty" do
+      event = create(:event, number_of_participants: 4, start_time: 2.days.from_now)
+
+      expect {
+        event.notify_bench_reminder!
+      }.not_to change { Notification.where(kind: :reminder).count }
+    end
+
+    it "is idempotent for the same start_time" do
+      event = create(:event, number_of_participants: 4, start_time: 2.days.from_now)
+      bench_player = create(:user)
+      create(:event_participant, user: bench_player, event: event, event_team: team_slot(event, "bench"))
+
+      event.notify_bench_reminder!
+
+      expect {
+        event.notify_bench_reminder!
+      }.not_to change { bench_player.notifications.reminder.count }
+    end
+
+    it "sends again after start_time changes" do
+      event = create(:event, number_of_participants: 4, start_time: 2.days.from_now)
+      bench_player = create(:user)
+      create(:event_participant, user: bench_player, event: event, event_team: team_slot(event, "bench"))
+      event.notify_bench_reminder!
+
+      # Skip reschedule callbacks so :notification_jobs does not auto-run the new delayed job.
+      event.update_columns(start_time: 4.days.from_now)
+
+      expect {
+        event.notify_bench_reminder!
+      }.to change { bench_player.notifications.reminder.count }.by(1)
+    end
+  end
+
+  describe Events::BenchReminderJob do
+    it "no-ops when expected_start_time is stale" do
+      event = create(:event, start_time: 3.days.from_now)
+      create(:event_participant, user: create(:user), event: event, event_team: team_slot(event, "bench"))
+      stale = event.start_time.iso8601
+      event.update!(start_time: 5.days.from_now)
+
+      expect {
+        described_class.perform_now(event_id: event.id, expected_start_time: stale)
+      }.not_to change { Notification.where(kind: :reminder).count }
+    end
+
+    it "no-ops when the event was destroyed" do
+      expect {
+        described_class.perform_now(event_id: 0, expected_start_time: 1.day.from_now.iso8601)
+      }.not_to change { Notification.where(kind: :reminder).count }
+    end
+  end
+end

--- a/spec/models/event_participant_spec.rb
+++ b/spec/models/event_participant_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe EventParticipant, type: :model do
       }.not_to change { Notification.where(kind: :joined).count }
     end
 
-    it "notifies remaining team players when a player leaves team_one or team_two" do
+    it "notifies remaining team and bench players when a player leaves team_one or team_two" do
       event = create(:event)
       player = create(:user)
       team_player = create(:user)
@@ -211,7 +211,7 @@ RSpec.describe EventParticipant, type: :model do
 
       expect(event.user.notifications.where(kind: :left).count).to eq(author_count + 1)
       expect(team_player.notifications.where(kind: :left).count).to eq(team_player_count + 1)
-      expect(bench_player.notifications.where(kind: :left).count).to eq(bench_player_count)
+      expect(bench_player.notifications.where(kind: :left).count).to eq(bench_player_count + 1)
       expect(player.notifications.where(kind: :left).count).to eq(leaving_player_count)
     end
 
@@ -256,18 +256,21 @@ RSpec.describe EventParticipant, type: :model do
         .and change { Notification.where(kind: :left).count }.by(0)
     end
 
-    it "notifies countable players when a player moves from a countable team to the bench" do
+    it "notifies countable and bench players when a player moves from a countable team to the bench" do
       event = create(:event)
       team_player = create(:user)
-      bench_player = create(:user)
-      participant = create(:event_participant, user: bench_player, event: event, event_team: team_slot(event, "team_one"))
+      other_bench = create(:user)
+      moving = create(:user)
+      participant = create(:event_participant, user: moving, event: event, event_team: team_slot(event, "team_one"))
 
       create(:event_participant, user: team_player, event: event, event_team: team_slot(event, "team_two"))
+      create(:event_participant, user: other_bench, event: event, event_team: team_slot(event, "bench"))
 
       expect {
         participant.update!(event_team: team_slot(event, "bench"))
       }.to change { event.user.notifications.where(kind: :left).count }.by(1)
         .and change { team_player.notifications.where(kind: :left).count }.by(1)
+        .and change { other_bench.notifications.where(kind: :left).count }.by(1)
         .and change { Notification.where(kind: :joined).count }.by(0)
     end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Notification, type: :model do
       expect(described_class.kinds).not_to have_key("created")
     end
 
-    it "defines all MVP kinds including reserved reminder" do
+    it "defines all MVP kinds including reminder" do
       expect(described_class.kinds.keys).to contain_exactly(
         "updated", "canceled", "reminder", "joined", "left", "invited", "friendship_requested"
       )
@@ -233,16 +233,19 @@ RSpec.describe Notification, type: :model do
       )
     end
 
-    it "creates left for remaining countable squad members when a player leaves" do
+    it "creates left for remaining countable and bench players when a player leaves" do
       event = create(:event)
       teammate = create(:user)
+      bench_player = create(:user)
       leaving = create(:user)
       create(:event_participant, user: teammate, event: event, event_team: team_slot(event, "team_two"))
+      create(:event_participant, user: bench_player, event: event, event_team: team_slot(event, "bench"))
       participant = create(:event_participant, user: leaving, event: event, event_team: team_slot(event, "team_one"))
 
       expect {
         participant.destroy!
       }.to change { teammate.notifications.left.count }.by(1)
+        .and change { bench_player.notifications.left.count }.by(1)
         .and change { event.user.notifications.left.count }.by(1)
         .and change { leaving.notifications.left.count }.by(0)
 


### PR DESCRIPTION
- Added `Events::BenchReminderJob` to schedule reminders for bench users 24 hours before an event starts.
- Introduced `Event::BenchReminder` module to manage scheduling and notification logic.
- Updated `Event` model to include methods for calculating remaining spots and handling reminder notifications.
- Enhanced notification payload to include author, title, and remaining spots for reminders.
- Modified notification delivery to include bench users when participants leave countable teams.
- Updated locale files for reminder messages in English and French.
- Added tests to ensure correct behavior of reminder scheduling and notification delivery.