### PR TITLE
Implement JSON API with JWT authentication and enhance documentation

### DIFF
--- a/.cursor/rules/flipflapp-rails.mdc
+++ b/.cursor/rules/flipflapp-rails.mdc
@@ -10,9 +10,10 @@ Football `Event` organizer MVP. Read [docs/PROJECT.md](../../docs/PROJECT.md) fo
 ## Workflow
 
 1. [docs/DOMAIN.md](../../docs/DOMAIN.md) — business rules
-2. [docs/TESTING.md](../../docs/TESTING.md) — clarify → migrations (if approved) → specs → code
+2. [docs/TESTING.md](../../docs/TESTING.md) — clarify → migrations (if approved) → specs → code → API if needed
 3. [docs/RAILS_STYLEGUIDE.md](../../docs/RAILS_STYLEGUIDE.md) — Rails, RuboCop, file size
 4. [docs/FRONTEND.md](../../docs/FRONTEND.md) — ERB, Tailwind, components, Stimulus
+5. [docs/API.md](../../docs/API.md) — JSON `/api/v1` when the mobile contract changes
 
 ## Hard limits
 
@@ -27,6 +28,7 @@ Football `Event` organizer MVP. Read [docs/PROJECT.md](../../docs/PROJECT.md) fo
 |-------|-----|
 | Product | [PROJECT.md](../../docs/PROJECT.md) |
 | Domain | [DOMAIN.md](../../docs/DOMAIN.md) |
+| JSON API | [API.md](../../docs/API.md) |
 | TDD / features | [TESTING.md](../../docs/TESTING.md) |
 | Style | [RAILS_STYLEGUIDE.md](../../docs/RAILS_STYLEGUIDE.md) |
 | Commands | [DEVELOPMENT.md](../../docs/DEVELOPMENT.md) |

--- a/.cursor/skills/flipflapp-rails/SKILL.md
+++ b/.cursor/skills/flipflapp-rails/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: flipflapp-rails
 description: >-
-  FlipFlapp feature workflow: DOMAIN → TESTING → RAILS_STYLEGUIDE.
-  Use for models, controllers, views, specs, or migrations.
+  FlipFlapp feature workflow: DOMAIN → TESTING → RAILS_STYLEGUIDE → API.
+  Use for models, controllers, views, specs, API, or migrations.
 ---
 
 # FlipFlapp Rails skill
@@ -11,8 +11,9 @@ description: >-
 
 1. [docs/PROJECT.md](../../docs/PROJECT.md) — in scope?
 2. [docs/DOMAIN.md](../../docs/DOMAIN.md) — business rules
-3. [config/routes.rb](../../config/routes.rb) — HTTP surface
+3. [config/routes.rb](../../config/routes.rb) — HTTP surface (web + `/api/v1`)
 4. Nearby code in the same layer — copy conventions
+5. If mobile clients are affected — [docs/API.md](../../docs/API.md)
 
 ## Feature workflow
 
@@ -24,15 +25,17 @@ Follow [docs/TESTING.md](../../docs/TESTING.md):
 4. Propose migrations — user validates before any `db/migrate/` file
 5. Failing `spec/models/` specs
 6. Implement (model first, then controllers / views)
+7. If the HTTP contract for mobile changes — update `/api/v1`, `spec/requests/api/v1/`, serializers, and OpenAPI (rswag) in the same change
 
 ## Style
 
 - [docs/RAILS_STYLEGUIDE.md](../../docs/RAILS_STYLEGUIDE.md) — Rails, RuboCop, &lt;150 lines
 - [docs/FRONTEND.md](../../docs/FRONTEND.md) — ERB, Tailwind, components, Stimulus
+- API resource names = web names (`event_participants`, not aliases)
 
 ## Commands (only when user asks)
 
-See [docs/DEVELOPMENT.md](../../docs/DEVELOPMENT.md): `bin/dev`, `rspec`, `bin/rubocop`.
+See [docs/DEVELOPMENT.md](../../docs/DEVELOPMENT.md): `bin/dev`, `rspec`, `bin/rubocop`, `rake rswag:specs:swaggerize`.
 
 ## Do not
 

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ RAILS_MASTER_KEY=your_rails_master_key
 
 SMTP_USERNAME=your_smtp_username
 SMTP_PASSWORD=your_smtp_password
+
+# Optional — JWT signing for /api/v1 (defaults to secret_key_base)
+# DEVISE_JWT_SECRET_KEY=generate_a_long_random_secret

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,11 @@ Codex must understand the task before editing. For every non-trivial change:
 
 1. [docs/PROJECT.md](docs/PROJECT.md) — scope and MVP completion gates
 2. [docs/DOMAIN.md](docs/DOMAIN.md) — business rules
-3. [docs/TESTING.md](docs/TESTING.md) — feature workflow (clarify → migrations if approved → specs → code)
+3. [docs/TESTING.md](docs/TESTING.md) — feature workflow (clarify → migrations if approved → specs → code → API if mobile contract changes)
 4. [docs/RAILS_STYLEGUIDE.md](docs/RAILS_STYLEGUIDE.md) — Rails, RuboCop, &lt;150 lines
 5. [docs/FRONTEND.md](docs/FRONTEND.md) — ERB, Tailwind, components, Stimulus
-6. [docs/CODEX_PLAYBOOK.md](docs/CODEX_PLAYBOOK.md) — Codex task protocol and permission matrix
+6. [docs/API.md](docs/API.md) — JSON `/api/v1` for mobile
+7. [docs/CODEX_PLAYBOOK.md](docs/CODEX_PLAYBOOK.md) — Codex task protocol and permission matrix
 
 ## Hard limits
 
@@ -36,7 +37,7 @@ Codex must understand the task before editing. For every non-trivial change:
 
 ## Framework-first implementation
 
-- Prefer Rails 8, Active Record, Devise, Hotwire, Stimulus, Solid Queue, Solid Cable, Ransack, CarrierWave, and existing project APIs before custom infrastructure.
+- Prefer Rails 8, Active Record, Devise (+ devise-jwt for `/api/v1`), Hotwire, Stimulus, Solid Queue, Solid Cable, Ransack, CarrierWave, Alba, and existing project APIs before custom infrastructure.
 - Before hand-writing framework boilerplate, identify the installed framework generator or command that would create it.
 - Because commands require approval, propose the exact command and expected files first. Run it only after the user approves.
 - After an approved generator runs, remove unused output and adapt the result to project conventions. Never use a generator as permission for a migration.
@@ -77,6 +78,7 @@ Codex must understand the task before editing. For every non-trivial change:
 |-------|-----|
 | Product | [docs/PROJECT.md](docs/PROJECT.md) |
 | Domain | [docs/DOMAIN.md](docs/DOMAIN.md) |
+| JSON API | [docs/API.md](docs/API.md) |
 | TDD / features | [docs/TESTING.md](docs/TESTING.md) |
 | Style | [docs/RAILS_STYLEGUIDE.md](docs/RAILS_STYLEGUIDE.md) |
 | Commands | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) |
@@ -96,6 +98,6 @@ Codex must understand the task before editing. For every non-trivial change:
 | GitHub Copilot | [.github/copilot-instructions.md](.github/copilot-instructions.md) |
 | Codex prompts | [docs/CODEX_PLAYBOOK.md](docs/CODEX_PLAYBOOK.md) |
 
-Layer context when editing: `app/models/AGENTS.md`, `app/controllers/AGENTS.md`, `app/jobs/AGENTS.md`, `app/views/AGENTS.md`, `app/javascript/AGENTS.md`, `spec/AGENTS.md`.
+Layer context when editing: `app/models/AGENTS.md`, `app/controllers/AGENTS.md`, `app/controllers/api/AGENTS.md`, `app/jobs/AGENTS.md`, `app/views/AGENTS.md`, `app/javascript/AGENTS.md`, `spec/AGENTS.md`.
 
 Do not duplicate long rule blocks outside `docs/` — link instead.

--- a/Gemfile
+++ b/Gemfile
@@ -84,4 +84,4 @@ gem "alba", "~> 3.10"
 gem "rack-cors", "~> 3.0"
 gem "rswag", "~> 2.17"
 
-gem "rswag-specs", "~> 2.17", groups: [:development, :test]
+gem "rswag-specs", "~> 2.17", groups: [ :development, :test ]

--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,10 @@ gem "cloudinary"
 gem "carrierwave"
 
 gem "ransack"
+
+gem "devise-jwt", "~> 0.13.0"
+gem "alba", "~> 3.10"
+gem "rack-cors", "~> 3.0"
+gem "rswag", "~> 2.17"
+
+gem "rswag-specs", "~> 2.17", groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    alba (3.10.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -124,12 +125,25 @@ GEM
       railties (>= 7.0)
       responders
       warden (~> 1.2.3)
+    devise-jwt (0.13.0)
+      devise (>= 4.0.0, < 6.0.0)
+      warden-jwt_auth (~> 0.10)
     diff-lcs (1.6.2)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
       railties (>= 6.1)
     drb (2.2.3)
+    dry-auto_inject (1.2.1)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-core (1.2.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
     ed25519 (1.4.0)
     erb (6.0.4)
     erubi (1.13.1)
@@ -183,6 +197,11 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.21.1)
+    json-schema (6.2.0)
+      addressable (~> 2.8)
+      bigdecimal (>= 3.1, < 5)
+    jwt (3.2.0)
+      base64
     kamal (2.12.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -280,6 +299,9 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -359,6 +381,21 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
+    rswag (2.17.0)
+      rswag-api (= 2.17.0)
+      rswag-specs (= 2.17.0)
+      rswag-ui (= 2.17.0)
+    rswag-api (2.17.0)
+      activesupport (>= 5.2, < 8.2)
+      railties (>= 5.2, < 8.2)
+    rswag-specs (2.17.0)
+      activesupport (>= 5.2, < 8.2)
+      json-schema (>= 2.2, < 7.0)
+      railties (>= 5.2, < 8.2)
+      rspec-core (>= 2.14)
+    rswag-ui (2.17.0)
+      actionpack (>= 5.2, < 8.2)
+      railties (>= 5.2, < 8.2)
     rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -441,6 +478,11 @@ GEM
     useragent (0.16.11)
     warden (1.2.9)
       rack (>= 2.0.9)
+    warden-jwt_auth (0.12.0)
+      dry-auto_inject (>= 0.8, < 2)
+      dry-configurable (>= 0.13, < 2)
+      jwt (>= 2.1, < 4)
+      warden (~> 1.2)
     web-console (4.3.0)
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
@@ -467,6 +509,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  alba (~> 3.10)
   bootsnap
   brakeman
   capybara
@@ -475,6 +518,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  devise-jwt (~> 0.13.0)
   dotenv-rails
   factory_bot_rails
   faker
@@ -484,9 +528,12 @@ DEPENDENCIES
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
+  rack-cors (~> 3.0)
   rails (~> 8.0.2, >= 8.0.2.1)
   ransack
   rspec-rails
+  rswag (~> 2.17)
+  rswag-specs (~> 2.17)
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/app/controllers/api/AGENTS.md
+++ b/app/controllers/api/AGENTS.md
@@ -1,0 +1,10 @@
+# API controllers
+
+Layer under `app/controllers/api/`.
+
+- Inherit from `Api::V1::BaseController` (`ActionController::API`), not `ApplicationController`
+- Mirror web resource names exactly (`event_teams`, `event_participants`, `friendships`, …) — Convention over Configuration
+- Thin: auth, strong params, model domain methods, Alba serializers
+- Domain rules stay in models; never duplicate visibility / capacity / invite logic
+- When a feature changes the mobile HTTP contract, update API + OpenAPI (`spec/requests/api/v1`, rswag) in the same change
+- Docs: [docs/API.md](../../../docs/API.md), [docs/TESTING.md](../../../docs/TESTING.md), [docs/DOMAIN.md](../../../docs/DOMAIN.md)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class BaseController < ActionController::API
+      before_action :authenticate_user!
+
+      rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+
+      private
+
+      def render_error(message, status, details: nil)
+        payload = { error: { message: message } }
+        payload[:error][:details] = details if details.present?
+        render json: payload, status: status
+      end
+
+      def render_not_found
+        render_error("Not found", :not_found)
+      end
+
+      def render_forbidden(message = "Forbidden")
+        render_error(message, :forbidden)
+      end
+
+      def render_validation_errors(record)
+        render_error(
+          "Validation failed",
+          :unprocessable_entity,
+          details: record.errors.to_hash(true)
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/event_participants_controller.rb
+++ b/app/controllers/api/v1/event_participants_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class EventParticipantsController < BaseController
+      before_action :set_event, except: :destroy
+
+      def index
+        scope = @event.event_participants.includes(:user)
+        if params[:event_team_id].present?
+          scope = scope.where(event_team_id: params[:event_team_id])
+        end
+        render json: EventParticipantSerializer.new(scope).serializable_hash
+      end
+
+      def create
+        unless @event.joinable_by?(current_user)
+          return render_not_found
+        end
+
+        event_participant = @event.event_participants.find_or_initialize_by(user: current_user)
+        event_team = @event.event_teams.find_by(id: event_participant_params[:event_team_id])
+        return render_not_found unless event_team
+
+        event_participant.assign_attributes(event_team: event_team)
+        if event_participant.save
+          render json: EventParticipantSerializer.new(event_participant).serializable_hash,
+                 status: event_participant.previously_new_record? ? :created : :ok
+        else
+          render_validation_errors(event_participant)
+        end
+      end
+
+      def destroy
+        event_participant = current_user.event_participants.find_by(id: params[:id])
+        return render_not_found unless event_participant
+
+        event_participant.destroy!
+        head :no_content
+      end
+
+      private
+
+      def set_event
+        @event = Event.find(params[:event_id])
+        render_not_found unless @event.viewable_by?(current_user)
+      end
+
+      def event_participant_params
+        params.require(:event_participant).permit(:event_team_id)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/event_teams_controller.rb
+++ b/app/controllers/api/v1/event_teams_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class EventTeamsController < BaseController
+      before_action :set_event
+      before_action :set_event_team, only: %i[show update]
+      before_action :authorize_participant!, only: :update
+      before_action :authorize_countable_team!, only: :update
+
+      def index
+        event_teams = @event.event_teams.order(:slot)
+        render json: EventTeamSerializer.new(event_teams).serializable_hash
+      end
+
+      def show
+        render json: EventTeamSerializer.new(@event_team).serializable_hash
+      end
+
+      def update
+        if @event_team.update(event_team_params)
+          render json: EventTeamSerializer.new(@event_team).serializable_hash
+        else
+          render_validation_errors(@event_team)
+        end
+      end
+
+      private
+
+      def set_event
+        @event = Event.find(params[:event_id])
+        render_not_found unless @event.viewable_by?(current_user)
+      end
+
+      def set_event_team
+        @event_team = @event.event_teams.find(params[:id])
+      end
+
+      def authorize_participant!
+        render_forbidden unless @event.in_this_event?(current_user)
+      end
+
+      def authorize_countable_team!
+        render_forbidden unless @event_team.countable?
+      end
+
+      def event_team_params
+        params.require(:event_team).permit(:label)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/events/invitations_controller.rb
+++ b/app/controllers/api/v1/events/invitations_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Events
+      class InvitationsController < BaseController
+        before_action :set_event
+
+        def index
+          invitations = @event.invitations.includes(:user).order(:created_at)
+          render json: InvitationSerializer.new(invitations).serializable_hash
+        end
+
+        def create
+          unless @event.can_invite?(current_user)
+            return render_forbidden
+          end
+
+          user_ids = Array(params[:user_ids]).reject(&:blank?)
+          if user_ids.empty?
+            return render_error("No users to invite", :unprocessable_entity)
+          end
+
+          invited_friends = current_user.get_my_friends_but_not_participants(@event).where(id: user_ids)
+          if invited_friends.empty?
+            return render_error("No users to invite", :unprocessable_entity)
+          end
+
+          @event.invite!(users: invited_friends, sender: current_user)
+          invitations = @event.invitations.where(user: invited_friends).includes(:user)
+          render json: InvitationSerializer.new(invitations).serializable_hash, status: :created
+        end
+
+        private
+
+        def set_event
+          @event = Event.find(params[:event_id])
+          render_not_found unless @event.viewable_by?(current_user)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class EventsController < BaseController
+      before_action :set_event, only: %i[show update destroy]
+      before_action :authorize_event_view!, only: %i[show update destroy]
+      before_action :authorize_event_owner!, only: %i[update destroy]
+
+      def index
+        events = Event.visible_to(current_user)
+                      .with_countable_participants_count
+                      .upcoming
+                      .includes(:user)
+        render json: EventSerializer.new(events, params: { current_user: current_user }).serializable_hash
+      end
+
+      def show
+        render json: EventSerializer.new(@event, params: { current_user: current_user }).serializable_hash
+      end
+
+      def create
+        event = current_user.events.build(event_params)
+        if event.save
+          render json: EventSerializer.new(event, params: { current_user: current_user }).serializable_hash,
+                 status: :created
+        else
+          render_validation_errors(event)
+        end
+      end
+
+      def update
+        if @event.update(event_params)
+          render json: EventSerializer.new(@event, params: { current_user: current_user }).serializable_hash
+        else
+          render_validation_errors(@event)
+        end
+      end
+
+      def destroy
+        @event.destroy!
+        head :no_content
+      end
+
+      private
+
+      def set_event
+        @event = Event.find(params[:id])
+      end
+
+      def authorize_event_view!
+        render_not_found unless @event.viewable_by?(current_user)
+      end
+
+      def authorize_event_owner!
+        render_forbidden unless @event.am_i_the_author?(current_user)
+      end
+
+      def event_params
+        params.require(:event).permit(
+          :title, :description, :location, :start_time, :number_of_participants,
+          :price, :is_private, :latitude, :longitude
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/friendships_controller.rb
+++ b/app/controllers/api/v1/friendships_controller.rb
@@ -22,7 +22,7 @@ module Api
 
       def search
         q = User.users_without_friendship(current_user).ransack(params[:q])
-        users = params[:q].present? ? q.result.select(:id, :email, :first_name, :last_name, :username, :role).distinct : User.none
+        users = params[:q].present? ? q.result.select(:id, :first_name, :last_name, :username).distinct : User.none
         render json: UserSerializer.new(users).serializable_hash
       end
 

--- a/app/controllers/api/v1/friendships_controller.rb
+++ b/app/controllers/api/v1/friendships_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FriendshipsController < BaseController
+      def index
+        render json: {
+          accepted: FriendshipSerializer.new(
+            current_user.accepted_friendships.includes(:sender, :receiver)
+          ).serializable_hash,
+          sent: FriendshipSerializer.new(
+            current_user.pending_sent_friendships.includes(:receiver)
+          ).serializable_hash,
+          received: FriendshipSerializer.new(
+            current_user.pending_received_friendships.includes(:sender)
+          ).serializable_hash,
+          declined: FriendshipSerializer.new(
+            current_user.declined_received_friendships.includes(:sender)
+          ).serializable_hash
+        }
+      end
+
+      def search
+        q = User.users_without_friendship(current_user).ransack(params[:q])
+        users = params[:q].present? ? q.result.select(:id, :email, :first_name, :last_name, :username, :role).distinct : User.none
+        render json: UserSerializer.new(users).serializable_hash
+      end
+
+      def create
+        user = User.find(params[:user_id])
+        friendship = current_user.sent_friendships.build(receiver: user, status: "pending")
+        if friendship.save
+          render json: FriendshipSerializer.new(friendship).serializable_hash, status: :created
+        else
+          render_validation_errors(friendship)
+        end
+      end
+
+      def update
+        friendship = Friendship.find(params[:id])
+        unless friendship.receiver == current_user && friendship.status == "pending"
+          return render_forbidden
+        end
+
+        if params[:status] == "declined"
+          return render_forbidden unless friendship.decline
+
+          render json: FriendshipSerializer.new(friendship).serializable_hash
+        elsif friendship.accept
+          render json: FriendshipSerializer.new(friendship).serializable_hash
+        else
+          render_validation_errors(friendship)
+        end
+      end
+
+      def destroy
+        friendship = Friendship.find(params[:id])
+        allowed =
+          (friendship.receiver == current_user && friendship.status == "declined") ||
+          ((friendship.sender == current_user || friendship.receiver == current_user) && friendship.status == "accepted") ||
+          (friendship.sender == current_user && friendship.status == "pending")
+
+        return render_forbidden unless allowed
+
+        friendship.destroy!
+        head :no_content
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class NotificationsController < BaseController
+      before_action :set_notification, only: %i[read destroy]
+
+      def index
+        notifications = current_user.notifications.inbox.recent
+        render json: NotificationSerializer.new(notifications).serializable_hash
+      end
+
+      def read
+        @notification.mark_as_read!
+        render json: NotificationSerializer.new(@notification).serializable_hash
+      end
+
+      def read_all
+        Notification.mark_all_as_read_for!(current_user)
+        head :no_content
+      end
+
+      def destroy
+        @notification.destroy!
+        head :no_content
+      end
+
+      private
+
+      def set_notification
+        @notification = current_user.notifications.inbox.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users/confirmations_controller.rb
+++ b/app/controllers/api/v1/users/confirmations_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      class ConfirmationsController < Devise::ConfirmationsController
+        respond_to :json
+        skip_before_action :verify_authenticity_token
+
+        def create
+          self.resource = resource_class.send_confirmation_instructions(resource_params)
+          if successfully_sent?(resource)
+            head :no_content
+          else
+            render json: {
+              error: {
+                message: "Validation failed",
+                details: resource.errors.to_hash(true)
+              }
+            }, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users/passwords_controller.rb
+++ b/app/controllers/api/v1/users/passwords_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      class PasswordsController < Devise::PasswordsController
+        respond_to :json
+        skip_before_action :verify_authenticity_token
+
+        def create
+          self.resource = resource_class.send_reset_password_instructions(resource_params)
+          if successfully_sent?(resource)
+            head :no_content
+          else
+            render json: {
+              error: {
+                message: "Validation failed",
+                details: resource.errors.to_hash(true)
+              }
+            }, status: :unprocessable_entity
+          end
+        end
+
+        def update
+          self.resource = resource_class.reset_password_by_token(resource_params)
+          if resource.errors.empty?
+            head :no_content
+          else
+            render json: {
+              error: {
+                message: "Validation failed",
+                details: resource.errors.to_hash(true)
+              }
+            }, status: :unprocessable_entity
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -12,7 +12,7 @@ module Api
 
         def respond_with(resource, _opts = {})
           if resource.persisted?
-            render json: UserSerializer.new(resource).serializable_hash, status: :created
+            render json: CurrentUserSerializer.new(resource).serializable_hash, status: :created
           else
             render json: {
               error: {

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      class RegistrationsController < Devise::RegistrationsController
+        respond_to :json
+        skip_before_action :verify_authenticity_token
+        before_action :configure_sign_up_params, only: :create
+
+        private
+
+        def respond_with(resource, _opts = {})
+          if resource.persisted?
+            render json: UserSerializer.new(resource).serializable_hash, status: :created
+          else
+            render json: {
+              error: {
+                message: "Validation failed",
+                details: resource.errors.to_hash(true)
+              }
+            }, status: :unprocessable_entity
+          end
+        end
+
+        def configure_sign_up_params
+          devise_parameter_sanitizer.permit(:sign_up, keys: [ :first_name, :last_name, :avatar ])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      class SessionsController < Devise::SessionsController
+        respond_to :json
+        skip_before_action :verify_authenticity_token
+        skip_before_action :authenticate_user!, raise: false
+
+        private
+
+        def respond_with(resource, _opts = {})
+          render json: UserSerializer.new(resource).serializable_hash, status: :ok
+        end
+
+        def respond_to_on_destroy(*)
+          head :no_content
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -11,7 +11,7 @@ module Api
         private
 
         def respond_with(resource, _opts = {})
-          render json: UserSerializer.new(resource).serializable_hash, status: :ok
+          render json: CurrentUserSerializer.new(resource).serializable_hash, status: :ok
         end
 
         def respond_to_on_destroy(*)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class UsersController < BaseController
       def me
-        render json: UserSerializer.new(current_user).serializable_hash
+        render json: CurrentUserSerializer.new(current_user).serializable_hash
       end
 
       def show
@@ -14,7 +14,7 @@ module Api
 
       def update
         if current_user.update(user_params)
-          render json: UserSerializer.new(current_user).serializable_hash
+          render json: CurrentUserSerializer.new(current_user).serializable_hash
         else
           render_validation_errors(current_user)
         end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UsersController < BaseController
+      def me
+        render json: UserSerializer.new(current_user).serializable_hash
+      end
+
+      def show
+        user = User.find(params[:id])
+        render json: UserSerializer.new(user).serializable_hash
+      end
+
+      def update
+        if current_user.update(user_params)
+          render json: UserSerializer.new(current_user).serializable_hash
+        else
+          render_validation_errors(current_user)
+        end
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:first_name, :last_name, :avatar, :email, :password, :password_confirmation)
+      end
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV["SMTP_USERNAME"]
+  default from: -> { ENV["SMTP_USERNAME"].presence || "noreply@flipflapp.fr" }
   layout "mailer"
 
   # Always use deliver_later (Active Job / Solid Queue). Prefer deliver_now only in console/debug.

--- a/app/models/jwt_denylist.rb
+++ b/app/models/jwt_denylist.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class JwtDenylist < ApplicationRecord
+  include Devise::JWT::RevocationStrategies::Denylist
+
+  self.table_name = "jwt_denylist"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,8 @@ class User < ApplicationRecord
   # Include default devise modules.
   devise :database_authenticatable, :registerable,
           :recoverable, :rememberable, :validatable,
-          :confirmable
+          :confirmable,
+          :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class UserSerializer
+class CurrentUserSerializer
   include Alba::Resource
 
-  attributes :id, :first_name, :last_name, :username
+  attributes :id, :email, :first_name, :last_name, :username, :role
 
   attribute :avatar_url do |user|
     user.avatar.url.presence

--- a/app/serializers/event_participant_serializer.rb
+++ b/app/serializers/event_participant_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EventParticipantSerializer
+  include Alba::Resource
+
+  attributes :id, :event_id, :event_team_id, :user_id, :created_at, :updated_at
+
+  attribute :user do |event_participant|
+    UserSerializer.new(event_participant.user).serializable_hash
+  end
+end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class EventSerializer
+  include Alba::Resource
+
+  attributes :id, :title, :description, :location, :start_time,
+             :number_of_participants, :price, :is_private,
+             :latitude, :longitude, :user_id, :created_at, :updated_at
+
+  attribute :participants_count, &:participants_count
+  attribute :spots_remaining, &:spots_remaining
+  attribute :fill_level, &:fill_level
+
+  attribute :user do |event|
+    UserSerializer.new(event.user).serializable_hash
+  end
+
+  attribute :current_user do |event|
+    viewer = params[:current_user]
+    next nil if viewer.blank?
+
+    {
+      participant: event.in_this_event?(viewer),
+      can_invite: event.can_invite?(viewer),
+      author: event.am_i_the_author?(viewer),
+      invited: event.invited?(viewer)
+    }
+  end
+end

--- a/app/serializers/event_team_serializer.rb
+++ b/app/serializers/event_team_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class EventTeamSerializer
+  include Alba::Resource
+
+  attributes :id, :event_id, :slot, :label, :created_at, :updated_at
+
+  attribute :countable, &:countable?
+end

--- a/app/serializers/friendship_serializer.rb
+++ b/app/serializers/friendship_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FriendshipSerializer
+  include Alba::Resource
+
+  attributes :id, :sender_id, :receiver_id, :status, :created_at, :updated_at
+
+  attribute :sender do |friendship|
+    UserSerializer.new(friendship.sender).serializable_hash
+  end
+
+  attribute :receiver do |friendship|
+    UserSerializer.new(friendship.receiver).serializable_hash
+  end
+end

--- a/app/serializers/invitation_serializer.rb
+++ b/app/serializers/invitation_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class InvitationSerializer
+  include Alba::Resource
+
+  attributes :id, :event_id, :user_id, :created_at, :updated_at
+
+  attribute :user do |invitation|
+    UserSerializer.new(invitation.user).serializable_hash
+  end
+end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class NotificationSerializer
+  include Alba::Resource
+
+  attributes :id, :user_id, :kind, :read, :payload,
+             :notifiable_type, :notifiable_id, :created_at, :updated_at
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UserSerializer
+  include Alba::Resource
+
+  attributes :id, :email, :first_name, :last_name, :username, :role
+
+  attribute :avatar_url do |user|
+    user.avatar.url.presence
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+    resource "/api/*",
+             headers: :any,
+             methods: %i[get post put patch delete options head],
+             expose: [ "Authorization" ]
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV["SMTP_USERNAME"]
+  config.mailer_sender = ENV["SMTP_USERNAME"].presence || "noreply@flipflapp.fr"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,4 +310,17 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+  # ==> Configuration for devise-jwt (API Bearer tokens; web sessions unchanged)
+  config.jwt do |jwt|
+    jwt.secret = ENV.fetch("DEVISE_JWT_SECRET_KEY") { Rails.application.secret_key_base }
+    jwt.dispatch_requests = [
+      [ "POST", %r{^/api/v1/users/sign_in$} ],
+      [ "POST", %r{^/api/v1/users$} ]
+    ]
+    jwt.revocation_requests = [
+      [ "DELETE", %r{^/api/v1/users/sign_out$} ]
+    ]
+    jwt.expiration_time = 7.days.to_i
+  end
 end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,14 +1,13 @@
 Rswag::Api.configure do |c|
-
   # Specify a root folder where Swagger JSON files are located
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.openapi_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.to_s + "/swagger"
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request
   # For example, you could leverage this to dynamically assign the "host" property
   #
-  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
 end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,5 +1,4 @@
 Rswag::Ui.configure do |c|
-
   # List the Swagger endpoints that you want to be documented through the
   # swagger-ui. The first parameter is the path (absolute or relative to the UI
   # host) to the corresponding endpoint and the second is a title that will be

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.openapi_endpoint "/api-docs/v1/swagger.yaml", "FlipFlapp API V1"
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,10 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
-  # Defines the root path route ("/")
-  # root "posts#index"
-  #
-  # Routes d'authentication
   authenticated :user do
     root to: "events#home", as: :authenticated_root
   end
@@ -20,6 +12,7 @@ Rails.application.routes.draw do
   unauthenticated do
     root to: "pages#home", as: :unauthenticated_root
   end
+
   devise_for :users, controllers: {
     confirmations: "users/confirmations",
     registrations: "users/registrations"
@@ -56,5 +49,42 @@ Rails.application.routes.draw do
     resources :friendships
     resources :invitations
     resources :notifications
+  end
+
+  namespace :api do
+    namespace :v1 do
+      devise_scope :user do
+        post "users/sign_in", to: "users/sessions#create"
+        delete "users/sign_out", to: "users/sessions#destroy"
+        post "users", to: "users/registrations#create"
+        post "users/password", to: "users/passwords#create"
+        patch "users/password", to: "users/passwords#update"
+        put "users/password", to: "users/passwords#update"
+        post "users/confirmation", to: "users/confirmations#create"
+      end
+
+      get "me", to: "users#me"
+      patch "me", to: "users#update"
+      resources :users, only: [ :show ]
+
+      resources :events, only: %i[index show create update destroy] do
+        resources :event_teams, only: %i[index show update] do
+          resources :event_participants, only: [ :index ]
+        end
+        resources :event_participants, only: %i[index create]
+        scope module: :events do
+          resources :invitations, only: %i[index create]
+        end
+      end
+      resources :event_participants, only: [ :destroy ]
+
+      get "friendships/search", to: "friendships#search"
+      resources :friendships, only: [ :index, :create, :update, :destroy ]
+
+      resources :notifications, only: [ :index, :destroy ] do
+        patch :read, on: :member
+        patch :read_all, on: :collection
+      end
+    end
   end
 end

--- a/db/migrate/20260721164117_create_jwt_denylist.rb
+++ b/db/migrate/20260721164117_create_jwt_denylist.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateJwtDenylist < ActiveRecord::Migration[8.0]
+  def change
+    create_table :jwt_denylist do |t|
+      t.string :jti, null: false
+      t.datetime :exp, null: false
+    end
+    add_index :jwt_denylist, :jti
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_21_153229) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_21_164117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -73,6 +73,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_21_153229) do
     t.index ["event_id", "user_id"], name: "index_invitations_on_event_id_and_user_id", unique: true
     t.index ["event_id"], name: "index_invitations_on_event_id"
     t.index ["user_id"], name: "index_invitations_on_user_id"
+  end
+
+  create_table "jwt_denylist", force: :cascade do |t|
+    t.string "jti", null: false
+    t.datetime "exp", null: false
+    t.index ["jti"], name: "index_jwt_denylist_on_jti"
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,136 @@
+# FlipFlapp JSON API (`/api/v1`)
+
+JSON API for iOS/Android clients. The web UI stays on session Devise; this API uses **Bearer JWT** (`devise-jwt`).
+
+Domain rules: [DOMAIN.md](DOMAIN.md). Feature workflow: [TESTING.md](TESTING.md). Interactive docs: **http://localhost:3000/api-docs** (Swagger UI).
+
+## Conventions
+
+- **Convention over Configuration** — resource names match the web app and Active Record: `events`, `event_teams`, `event_participants`, `friendships`, `invitations`, `notifications`, `users`, `me`.
+- Do **not** invent aliases (`teams`, `participants`, `invitees`, `auth`).
+- JSON keys match model attributes / associations (`event_team_id`, `user_id`, `slot`, …).
+- Controllers live under `app/controllers/api/v1/` and mirror web controller names.
+- Domain logic stays in models; API controllers only authenticate, authorize via model predicates, permit params, and serialize.
+
+## Auth
+
+1. `POST /api/v1/users/sign_in` with `{ "user": { "email", "password" } }`
+2. Read `Authorization: Bearer <jwt>` from the response header
+3. Send that header on subsequent requests
+4. `DELETE /api/v1/users/sign_out` revokes the token (`jwt_denylist`)
+
+Optional secret: `DEVISE_JWT_SECRET_KEY` (falls back to `secret_key_base`). Tokens expire after 7 days.
+
+| Method | Path | Notes |
+|--------|------|--------|
+| `POST` | `/api/v1/users` | Registration (confirmable — confirm via email before JWT login) |
+| `POST` | `/api/v1/users/sign_in` | Returns user JSON + `Authorization` header |
+| `DELETE` | `/api/v1/users/sign_out` | Revoke JWT |
+| `POST` | `/api/v1/users/password` | Request reset instructions |
+| `PATCH` | `/api/v1/users/password` | Reset with token |
+| `POST` | `/api/v1/users/confirmation` | Resend confirmation |
+| `GET` | `/api/v1/me` | Current user |
+| `PATCH` | `/api/v1/me` | Update profile (`user` strong params) |
+| `GET` | `/api/v1/users/:id` | Public profile fields |
+
+## Errors
+
+```json
+{ "error": { "message": "…", "details": { "field": ["…"] } } }
+```
+
+| Status | Meaning |
+|--------|---------|
+| `401` | Missing/invalid JWT or bad credentials |
+| `403` | Authenticated but not allowed |
+| `404` | Missing **or** not viewable (private events) |
+| `422` | Validation failed (`details` present) |
+
+## Resources
+
+### Events
+
+| Method | Path |
+|--------|------|
+| `GET` | `/api/v1/events` |
+| `POST` | `/api/v1/events` |
+| `GET` | `/api/v1/events/:id` |
+| `PATCH` | `/api/v1/events/:id` |
+| `DELETE` | `/api/v1/events/:id` |
+
+`GET` show includes `current_user`: `{ participant, can_invite, author, invited }`.
+
+### Event teams & participants (granular for iOS)
+
+| Method | Path |
+|--------|------|
+| `GET` | `/api/v1/events/:event_id/event_teams` |
+| `GET` | `/api/v1/events/:event_id/event_teams/:id` |
+| `PATCH` | `/api/v1/events/:event_id/event_teams/:id` |
+| `GET` | `/api/v1/events/:event_id/event_participants` |
+| `GET` | `/api/v1/events/:event_id/event_teams/:event_team_id/event_participants` |
+| `POST` | `/api/v1/events/:event_id/event_participants` |
+| `DELETE` | `/api/v1/event_participants/:id` |
+
+Join / switch team body: `{ "event_participant": { "event_team_id": 123 } }`.
+
+**iOS pattern:** after a join, refetch only  
+`/api/v1/events/:event_id/event_teams/:event_team_id/event_participants` — not the full event tree.
+
+Invite picker: use `GET /api/v1/friendships` (accepted) plus existing `event_participants` / `invitations` — same idea as web `get_my_friends_but_not_participants`. No `invitees` resource.
+
+### Invitations
+
+| Method | Path |
+|--------|------|
+| `GET` | `/api/v1/events/:event_id/invitations` |
+| `POST` | `/api/v1/events/:event_id/invitations` |
+
+Create body: `{ "user_ids": [1, 2] }` (accepted friends only).
+
+### Friendships
+
+| Method | Path |
+|--------|------|
+| `GET` | `/api/v1/friendships` |
+| `POST` | `/api/v1/friendships` |
+| `PATCH` | `/api/v1/friendships/:id` |
+| `DELETE` | `/api/v1/friendships/:id` |
+| `GET` | `/api/v1/friendships/search` |
+
+Index returns `{ accepted, sent, received, declined }`.  
+Create: `{ "user_id": 2 }`. Update: `{ "status": "accepted" }` or `"declined"`.
+
+### Notifications
+
+| Method | Path |
+|--------|------|
+| `GET` | `/api/v1/notifications` |
+| `PATCH` | `/api/v1/notifications/:id/read` |
+| `PATCH` | `/api/v1/notifications/read_all` |
+| `DELETE` | `/api/v1/notifications/:id` |
+
+Inbox excludes `friendship_requested` (same as web).
+
+## OpenAPI / testing
+
+- Specs: `spec/requests/api/v1/`
+- Generate OpenAPI: `bundle exec rake rswag:specs:swaggerize`
+- Artifact: `swagger/v1/swagger.yaml`
+- UI: `/api-docs`
+
+## Versioning
+
+- Current surface is **`v1`**. Breaking JSON/path changes require **`v2`**; do not silently break `v1`.
+- Additive fields on existing resources are allowed in `v1` when documented.
+
+## Feature co-evolution
+
+When a feature changes behavior that mobile clients consume:
+
+1. Update [DOMAIN.md](DOMAIN.md) if the rule changed
+2. Model specs first ([TESTING.md](TESTING.md))
+3. Update web if needed
+4. Update **`/api/v1`** controllers, serializers, request specs, and OpenAPI **in the same change**
+
+See also `app/controllers/api/AGENTS.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ Rails 8 monolith · PostgreSQL (Neon) · Devise · ERB + Tailwind CSS 4 · Hotwi
 ## Delivery phases
 
 1. **Web UI** — primary surface to implement and verify MVP behavior
-2. **JSON API** — same domain rules, after web flows are reliable (separate iOS/Android repos)
+2. **JSON API** — `/api/v1`, same domain rules (separate iOS/Android repos). See [API.md](API.md)
 
 ## MVC layers
 
@@ -18,6 +18,7 @@ Rails 8 monolith · PostgreSQL (Neon) · Devise · ERB + Tailwind CSS 4 · Hotwi
 | Models | `app/models/` | Domain behavior, validations, callbacks, `Notification` side effects via per-model modules (`Event::Notifications`, etc.) + `Notification::Delivery` (enqueues jobs) |
 | Jobs | `app/jobs/` | Solid Queue workers — e.g. `Notifications::DeliverOneJob` / `DeliverManyJob` (persist + Turbo Stream broadcast); local rules in [app/jobs/AGENTS.md](../app/jobs/AGENTS.md) |
 | Controllers | `app/controllers/` | Auth, strong params, HTTP — thin; call model domain methods |
+| API | `app/controllers/api/v1/` | JSON `/api/v1` — Bearer JWT; resource names mirror web; serializers in `app/serializers/` |
 | Views | `app/views/` | ERB + Tailwind; components under `<feature>/components/` |
 | JavaScript | `app/javascript/` | Stimulus when needed; ask before new controllers |
 | Specs | `spec/models/` | Behavior tests (strict TDD) |
@@ -30,7 +31,7 @@ Details: [DOMAIN.md](DOMAIN.md). Schema: `db/schema.rb`.
 
 ## HTTP surface
 
-`config/routes.rb` — RESTful resources, Devise, nested `Events::InvitationsController`, notifications.
+`config/routes.rb` — RESTful web resources, Devise sessions, nested `Events::InvitationsController`, notifications, plus `namespace :api / :v1` for mobile.
 
 ## Principles
 
@@ -50,5 +51,6 @@ Lock behavior with model specs before changing logic.
 | Need | Doc |
 |------|-----|
 | Rules | [DOMAIN.md](DOMAIN.md) |
+| JSON API | [API.md](API.md) |
 | Style | [RAILS_STYLEGUIDE.md](RAILS_STYLEGUIDE.md) |
 | Commands | [DEVELOPMENT.md](DEVELOPMENT.md) |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -42,6 +42,8 @@ bin/setup
 
 App URL: **http://localhost:3000** (override with `PORT=3001 bin/dev`).
 
+API docs (Swagger UI): **http://localhost:3000/api-docs** — see [API.md](API.md).
+
 ---
 
 ## Neon (development + test)
@@ -107,9 +109,11 @@ Prefer **`bin/…`** and direct gem binaries over `bundle exec` where available.
 
 | Command | Purpose |
 |---------|---------|
-| `rspec` | Full model spec suite (`TEST_NEON_DB` required) |
+| `rspec` | Full model + request spec suite (`TEST_NEON_DB` required) |
 | `rspec spec/models/event_spec.rb` | Single file |
 | `rspec spec/models/event_spec.rb:42` | Single example |
+| `rspec spec/requests/api/v1/` | JSON API request specs |
+| `bundle exec rake rswag:specs:swaggerize` | Regenerate `swagger/v1/swagger.yaml` |
 | `bin/rubocop` | Style (CI: lint job) |
 | `bin/brakeman --no-pager` | Security scan (CI: scan_ruby job) |
 
@@ -156,6 +160,7 @@ Review generated output immediately. Keep only files needed by the approved task
 | Need | Doc |
 |------|-----|
 | What to build | [DOMAIN.md](DOMAIN.md) |
+| JSON API | [API.md](API.md) |
 | How to test (TDD) | [TESTING.md](TESTING.md) |
 | Current schema | `db/schema.rb` |
 | Deploy & prod secrets | [DEPLOYMENT.md](DEPLOYMENT.md) |

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -506,7 +506,7 @@ Normal `User` (`role: player`) rules:
 ## Build order
 
 1. **Web** — full MVP behavior for all models above.
-2. **JSON API** — same behavior for iOS/Android repos once web flows are reliable.
+2. **JSON API** — `/api/v1` with Devise JWT; same domain rules for iOS/Android. See [API.md](API.md).
 
 Out of scope: payments, chat, rankings, Google OAuth. See [PROJECT.md](PROJECT.md).
 
@@ -550,7 +550,7 @@ See [TESTING.md](TESTING.md) — feature workflow is: clarify → domain → mig
 | `left` recipients include bench | **Implemented** — countable leave / countable→bench |
 | `created` `Notification` kind | **Removed** |
 | Admin stats dashboard | **Later** — out of MVP admin CRUD pass |
-| JSON API | **Not implemented** |
+| JSON API | **Implemented** — `/api/v1` (Devise JWT, Alba, OpenAPI/rswag). See [API.md](API.md) |
 | Google OAuth remnants (`users.tokens`, deploy `GOOGLE_CLIENT_*`) | **Removed** — email auth only; `provider`/`uid` kept for future OAuth |
 | `Friendship#decline` / `status: declined` | **Implemented** — receiver-only visibility; remove declined to allow re-request |
 | `Invitation` table (pending invite; unique per event + user) | **Implemented** — access via `Invitation`; `Notification.invited` for inbox only |

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -10,8 +10,8 @@
 
 ## This repository
 
-- Rails 8 app: **web UI** + **JSON API** (API comes after the web flows work end-to-end).
-- Web is the fast surface to **design, verify, and test** backend behavior before iOS/Android clients ship.
+- Rails 8 app: **web UI** + **JSON API** (`/api/v1` — see [API.md](API.md)).
+- Web is the fast surface to **design, verify, and test** backend behavior; mobile clients consume the same domain via the API.
 - Production: **flipflapp.fr**
 - Mobile apps live in **separate Swift and Kotlin repos** — not here.
 
@@ -31,7 +31,7 @@
 
 - Full behavior for `User`, `Event`, `EventTeam`, `EventParticipant`, `Friendship`, `Notification`.
 - `User` with `role: admin` — CRUD all MVP data (see [DOMAIN.md](DOMAIN.md)).
-- JSON API after web flows are reliable.
+- JSON API `/api/v1` for mobile clients ([API.md](API.md)).
 
 ## MVP quality target
 
@@ -44,7 +44,7 @@
 - **TDD contract** — model behavior is covered in `spec/models/`; material HTTP contracts are covered in `spec/requests/`.
 - **Consistent UI** — semantic ERB, existing Tailwind language, responsive layout, and I18n keys for user-facing copy.
 - **Operational fit** — background work uses the installed Rails stack, errors fail safely, and no secret or production-only assumption leaks into code.
-- **MVP discipline** — the solution adds no payments, chat, rankings, OAuth, mobile implementation, speculative API, or generalized abstraction.
+- **MVP discipline** — the solution adds no payments, chat, rankings, OAuth, mobile app code, or generalized abstraction. Keep `/api/v1` aligned with documented domain rules (no speculative endpoints).
 
 The target is a coherent, secure, maintainable football organizer—not a prototype with incomplete rules and not a platform built ahead of demand.
 
@@ -57,7 +57,7 @@ When requirements compete, decide in this order:
 3. Complete web MVP flow for the normal player journey.
 4. Simple conventional Rails implementation.
 5. UI polish using the existing Tailwind language.
-6. JSON API and future mobile needs only after the web behavior is reliable.
+6. Keep `/api/v1` and OpenAPI in sync when a feature changes the mobile HTTP contract ([API.md](API.md)).
 
 ## Out of scope
 
@@ -70,6 +70,7 @@ When requirements compete, decide in this order:
 | Question | Doc |
 |----------|-----|
 | Business rules | [DOMAIN.md](DOMAIN.md) |
+| JSON API / iOS | [API.md](API.md) |
 | Code style | [RAILS_STYLEGUIDE.md](RAILS_STYLEGUIDE.md) |
 | Feature development (TDD) | [TESTING.md](TESTING.md) |
 | Local setup and commands | [DEVELOPMENT.md](DEVELOPMENT.md) |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -19,6 +19,8 @@ Use this sequence for every behavior change:
 6. Implementation until specs pass (model first, then controllers / views / API as needed)
 ```
 
+When the change affects data or actions mobile clients use, **update `/api/v1` in the same change** (controllers, Alba serializers, `spec/requests/api/v1/`, OpenAPI via rswag). See [API.md](API.md).
+
 ### Step 1 — You describe the feature
 
 Explain the expected behavior in product terms. Reference models when possible (`Event`, `Friendship`, `Notification`, etc.).
@@ -55,6 +57,7 @@ Current schema: `db/schema.rb`.
 
 - Write or update specs in **`spec/models/`** first for domain rules.
 - Add **`spec/requests/`** when the HTTP contract must be locked (status, auth, side effects exposed via endpoints).
+- Add **`spec/requests/api/v1/`** (and rswag OpenAPI examples) when the JSON API contract changes.
 - Specs describe **behavior** from [DOMAIN.md](DOMAIN.md), not implementation details.
 - Use **Factory Bot** (`spec/factories/`). No YAML fixtures.
 - No `pending` examples.
@@ -66,6 +69,7 @@ Run (when you ask):
 ```bash
 rspec spec/models/
 rspec spec/requests/
+rspec spec/requests/api/v1/
 rspec spec/models/event_spec.rb
 ```
 
@@ -75,7 +79,7 @@ Uses `TEST_NEON_DB` — see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 1. **`app/models/`** — smallest change to pass specs (validations, scopes, callbacks, methods).
 2. **Controllers / views / Stimulus** — only to expose behavior already covered by model specs.
-3. **JSON API** — after web flows, same domain rules and specs as source of truth.
+3. **JSON API (`/api/v1`)** — when the feature changes a mobile HTTP contract: update API controllers, serializers, `spec/requests/api/v1/`, and regenerate OpenAPI (`rake rswag:specs:swaggerize`). Same domain rules as web; resource names match web (Convention over Configuration). See [API.md](API.md).
 
 Refactor only when it makes the tested behavior clearer. No service objects unless you explicitly request them.
 
@@ -92,7 +96,7 @@ Refactor only when it makes the tested behavior clearer. No service objects unle
 
 ## What to test
 
-Specs lock **backend behavior** from [DOMAIN.md](DOMAIN.md). They are the source of truth for the future iOS and Android JSON API — same rules, same side effects.
+Specs lock **backend behavior** from [DOMAIN.md](DOMAIN.md). They are the source of truth for the iOS and Android JSON API — same rules, same side effects.
 
 **`spec/models/`** — domain rules and data side effects:
 
@@ -109,6 +113,12 @@ Specs lock **backend behavior** from [DOMAIN.md](DOMAIN.md). They are the source
 - authentication and authorization (who can call an endpoint)
 - successful and rejected writes (e.g. join rejected when full)
 - backend side effects visible through the API (records created or destroyed)
+
+**`spec/requests/api/v1/`** — JSON API contract + OpenAPI (rswag):
+
+- Bearer JWT auth, status codes, JSON shapes
+- Resource names identical to web (`event_participants`, not aliases)
+- Regenerate `swagger/v1/swagger.yaml` after OpenAPI examples change
 
 Example: accepting a `Friendship` request **creates a `Notification`** → test in model or request spec.  
 Example: a **flash message** after the action → do **not** test; verify visually in the browser.
@@ -138,5 +148,6 @@ When in doubt: if the behavior is **data the mobile apps will need** (records, f
 | Need | Doc |
 |------|-----|
 | Business rules | [DOMAIN.md](DOMAIN.md) |
+| JSON API | [API.md](API.md) |
 | Commands | [DEVELOPMENT.md](DEVELOPMENT.md) |
 | Migrations policy | [AGENTS.md](../AGENTS.md) |

--- a/spec/requests/api/v1/event_teams_and_participants_spec.rb
+++ b/spec/requests/api/v1/event_teams_and_participants_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1 EventTeams and EventParticipants", type: :request do
+  describe "GET /api/v1/events/:event_id/event_teams" do
+    it "lists the three event_teams" do
+      user = create(:user)
+      event = create(:event, user: user)
+
+      api_get "/api/v1/events/#{event.id}/event_teams", user: user
+
+      expect(response).to have_http_status(:ok)
+      slots = JSON.parse(response.body).map { |t| t["slot"] }
+      expect(slots).to match_array(%w[team_one team_two bench])
+    end
+  end
+
+  describe "GET /api/v1/events/:event_id/event_teams/:event_team_id/event_participants" do
+    it "lists participants for one event_team" do
+      user = create(:user)
+      event = create(:event, user: user)
+      team_one = event.event_teams.find_by!(slot: "team_one")
+
+      api_get "/api/v1/events/#{event.id}/event_teams/#{team_one.id}/event_participants", user: user
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.length).to eq(1)
+      expect(body.first["user_id"]).to eq(user.id)
+      expect(body.first["event_team_id"]).to eq(team_one.id)
+    end
+  end
+
+  describe "POST /api/v1/events/:event_id/event_participants" do
+    it "joins an event_team" do
+      organizer = create(:user)
+      event = create(:event, user: organizer, is_private: false)
+      friend = create(:user)
+      create(:friendship, sender: organizer, receiver: friend, status: "accepted")
+      bench = event.event_teams.find_by!(slot: "bench")
+
+      expect {
+        api_post "/api/v1/events/#{event.id}/event_participants", user: friend, params: {
+          event_participant: { event_team_id: bench.id }
+        }
+      }.to change(EventParticipant, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)["event_team_id"]).to eq(bench.id)
+    end
+  end
+
+  describe "PATCH /api/v1/events/:event_id/event_teams/:id" do
+    it "renames a countable event_team label" do
+      user = create(:user)
+      event = create(:event, user: user)
+      team_one = event.event_teams.find_by!(slot: "team_one")
+
+      api_patch "/api/v1/events/#{event.id}/event_teams/#{team_one.id}", user: user, params: {
+        event_team: { label: "Les Bleus" }
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(team_one.reload.label).to eq("Les Bleus")
+    end
+  end
+
+  describe "DELETE /api/v1/event_participants/:id" do
+    it "allows a user to leave" do
+      organizer = create(:user)
+      event = create(:event, user: organizer, is_private: false)
+      friend = create(:user)
+      create(:friendship, sender: organizer, receiver: friend, status: "accepted")
+      team_two = event.event_teams.find_by!(slot: "team_two")
+      participation = create(:event_participant, event: event, user: friend, event_team: team_two)
+
+      expect {
+        api_delete "/api/v1/event_participants/#{participation.id}", user: friend
+      }.to change(EventParticipant, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1 Events", type: :request do
+  describe "GET /api/v1/events" do
+    it "lists visible upcoming events" do
+      user = create(:user)
+      visible = create(:event, user: user, is_private: false)
+      create(:event, is_private: true)
+
+      api_get "/api/v1/events", user: user
+
+      expect(response).to have_http_status(:ok)
+      ids = JSON.parse(response.body).map { |e| e["id"] }
+      expect(ids).to include(visible.id)
+    end
+  end
+
+  describe "GET /api/v1/events/:id" do
+    it "returns 404 for a private event the user cannot view" do
+      event = create(:event, is_private: true)
+      stranger = create(:user)
+
+      api_get "/api/v1/events/#{event.id}", user: stranger
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns the event with current_user context for the author" do
+      user = create(:user)
+      event = create(:event, user: user)
+
+      api_get "/api/v1/events/#{event.id}", user: user
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["id"]).to eq(event.id)
+      expect(body["current_user"]).to include("author" => true, "participant" => true)
+    end
+  end
+
+  describe "POST /api/v1/events" do
+    it "creates an event" do
+      user = create(:user)
+
+      expect {
+        api_post "/api/v1/events", user: user, params: {
+          event: {
+            title: "API Match",
+            description: "From API",
+            location: "Lyon",
+            start_time: 3.days.from_now,
+            number_of_participants: 10,
+            price: 5,
+            is_private: true,
+            latitude: 45.764043,
+            longitude: 4.835659
+          }
+        }
+      }.to change(Event, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)["title"]).to eq("API Match")
+    end
+  end
+
+  describe "PATCH /api/v1/events/:id" do
+    it "forbids non-authors who can view the event" do
+      organizer = create(:user)
+      friend = create(:user)
+      create(:friendship, sender: organizer, receiver: friend, status: "accepted")
+      event = create(:event, user: organizer, is_private: true)
+
+      api_patch "/api/v1/events/#{event.id}", user: friend, params: { event: { title: "Nope" } }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 404 for strangers on a private event" do
+      event = create(:event, is_private: true)
+      stranger = create(:user)
+
+      api_patch "/api/v1/events/#{event.id}", user: stranger, params: { event: { title: "Nope" } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE /api/v1/events/:id" do
+    it "destroys as author" do
+      user = create(:user)
+      event = create(:event, user: user)
+
+      expect {
+        api_delete "/api/v1/events/#{event.id}", user: user
+      }.to change(Event, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/spec/requests/api/v1/friendships_spec.rb
+++ b/spec/requests/api/v1/friendships_spec.rb
@@ -53,7 +53,13 @@ RSpec.describe "Api::V1 Friendships", type: :request do
       api_get "/api/v1/friendships/search", user: user, params: { q: { first_name_or_last_name_or_username_cont: "Zinedine" } }
 
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body).map { |u| u["id"] }).to include(other.id)
+      result = JSON.parse(response.body).find { |search_user| search_user["id"] == other.id }
+      expect(result).to include(
+        "first_name" => other.first_name,
+        "last_name" => other.last_name,
+        "username" => other.username
+      )
+      expect(result).not_to include("email", "role")
     end
   end
 end

--- a/spec/requests/api/v1/friendships_spec.rb
+++ b/spec/requests/api/v1/friendships_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1 Friendships", type: :request do
+  describe "GET /api/v1/friendships" do
+    it "returns friendship buckets" do
+      user = create(:user)
+      friend = create(:user)
+      create(:friendship, sender: user, receiver: friend, status: "accepted")
+
+      api_get "/api/v1/friendships", user: user
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.keys).to match_array(%w[accepted sent received declined])
+      expect(body["accepted"].length).to eq(1)
+    end
+  end
+
+  describe "POST /api/v1/friendships" do
+    it "creates a pending friendship" do
+      user = create(:user)
+      other = create(:user)
+
+      expect {
+        api_post "/api/v1/friendships", user: user, params: { user_id: other.id }
+      }.to change(Friendship, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)["status"]).to eq("pending")
+    end
+  end
+
+  describe "PATCH /api/v1/friendships/:id" do
+    it "accepts a pending request as receiver" do
+      sender = create(:user)
+      receiver = create(:user)
+      friendship = create(:friendship, sender: sender, receiver: receiver, status: "pending")
+
+      api_patch "/api/v1/friendships/#{friendship.id}", user: receiver, params: { status: "accepted" }
+
+      expect(response).to have_http_status(:ok)
+      expect(friendship.reload.status).to eq("accepted")
+    end
+  end
+
+  describe "GET /api/v1/friendships/search" do
+    it "searches users without friendship" do
+      user = create(:user)
+      other = create(:user, first_name: "Zinedine", last_name: "Zidane", username: "zizou#0001")
+
+      api_get "/api/v1/friendships/search", user: user, params: { q: { first_name_or_last_name_or_username_cont: "Zinedine" } }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).map { |u| u["id"] }).to include(other.id)
+    end
+  end
+end

--- a/spec/requests/api/v1/invitations_spec.rb
+++ b/spec/requests/api/v1/invitations_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1 Invitations", type: :request do
+  describe "POST /api/v1/events/:event_id/invitations" do
+    it "invites accepted friends" do
+      organizer = create(:user)
+      event = create(:event, user: organizer)
+      friend = create(:user)
+      create(:friendship, sender: organizer, receiver: friend, status: "accepted")
+
+      expect {
+        api_post "/api/v1/events/#{event.id}/invitations", user: organizer, params: {
+          user_ids: [ friend.id ]
+        }
+      }.to change(Invitation, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body).first["user_id"]).to eq(friend.id)
+    end
+  end
+
+  describe "GET /api/v1/events/:event_id/invitations" do
+    it "lists pending invitations" do
+      organizer = create(:user)
+      event = create(:event, user: organizer)
+      friend = create(:user)
+      create(:friendship, sender: organizer, receiver: friend, status: "accepted")
+      create(:invitation, event: event, user: friend)
+
+      api_get "/api/v1/events/#{event.id}/invitations", user: organizer
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).map { |i| i["user_id"] }).to include(friend.id)
+    end
+  end
+end

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1 Notifications", type: :request do
+  describe "GET /api/v1/notifications" do
+    it "lists inbox notifications" do
+      user = create(:user)
+      event = create(:event)
+      notification = create(:notification, user: user, notifiable: event, kind: :invited)
+
+      api_get "/api/v1/notifications", user: user
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).map { |n| n["id"] }).to include(notification.id)
+    end
+  end
+
+  describe "PATCH /api/v1/notifications/:id/read" do
+    it "marks a notification as read" do
+      user = create(:user)
+      event = create(:event)
+      notification = create(:notification, user: user, notifiable: event, kind: :invited, read: false)
+
+      api_patch "/api/v1/notifications/#{notification.id}/read", user: user
+
+      expect(response).to have_http_status(:ok)
+      expect(notification.reload.read).to be(true)
+    end
+  end
+
+  describe "PATCH /api/v1/notifications/read_all" do
+    it "marks all inbox notifications as read" do
+      user = create(:user)
+      event = create(:event)
+      create(:notification, user: user, notifiable: event, kind: :invited, read: false)
+
+      api_patch "/api/v1/notifications/read_all", user: user
+
+      expect(response).to have_http_status(:no_content)
+      expect(user.notifications.inbox.unread.count).to eq(0)
+    end
+  end
+end

--- a/spec/requests/api/v1/openapi_resources_spec.rb
+++ b/spec/requests/api/v1/openapi_resources_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Api::V1 Events OpenAPI", type: :request do
+  path "/api/v1/events" do
+    get "List events" do
+      tags "Events"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "events listed" do
+        let(:user_record) { create(:user) }
+        let(:Authorization) { api_auth_headers_for(user_record)["Authorization"] }
+        before { create(:event, user: user_record, is_private: false) }
+
+        run_test!
+      end
+
+      response "401", "unauthorized" do
+        let(:Authorization) { nil }
+        run_test!
+      end
+    end
+
+    post "Create event" do
+      tags "Events"
+      consumes "application/json"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+      parameter name: :event, in: :body, schema: {
+        type: :object,
+        properties: {
+          event: {
+            type: :object,
+            properties: {
+              title: { type: :string },
+              description: { type: :string },
+              location: { type: :string },
+              start_time: { type: :string, format: :"date-time" },
+              number_of_participants: { type: :integer },
+              price: { type: :number },
+              is_private: { type: :boolean },
+              latitude: { type: :number },
+              longitude: { type: :number }
+            },
+            required: %w[title location start_time number_of_participants price latitude longitude]
+          }
+        }
+      }
+
+      response "201", "event created" do
+        let(:user_record) { create(:user) }
+        let(:Authorization) { api_auth_headers_for(user_record)["Authorization"] }
+        let(:event) do
+          {
+            event: {
+              title: "OpenAPI Match",
+              description: "Doc",
+              location: "Paris",
+              start_time: 2.days.from_now.iso8601,
+              number_of_participants: 10,
+              price: 10,
+              is_private: true,
+              latitude: 48.856613,
+              longitude: 2.352222
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/events/{id}" do
+    parameter name: :id, in: :path, type: :string
+
+    get "Show event" do
+      tags "Events"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "event found" do
+        let(:user_record) { create(:user) }
+        let(:event_record) { create(:event, user: user_record) }
+        let(:id) { event_record.id }
+        let(:Authorization) { api_auth_headers_for(user_record)["Authorization"] }
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/me" do
+    get "Current user" do
+      tags "Users"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "current user" do
+        let(:user_record) { create(:user) }
+        let(:Authorization) { api_auth_headers_for(user_record)["Authorization"] }
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/events/{event_id}/event_teams" do
+    parameter name: :event_id, in: :path, type: :string
+
+    get "List event_teams" do
+      tags "EventTeams"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "event_teams listed" do
+        let(:user_record) { create(:user) }
+        let(:event_record) { create(:event, user: user_record) }
+        let(:event_id) { event_record.id }
+        let(:Authorization) { api_auth_headers_for(user_record)["Authorization"] }
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/events/{event_id}/event_teams/{event_team_id}/event_participants" do
+    parameter name: :event_id, in: :path, type: :string
+    parameter name: :event_team_id, in: :path, type: :string
+
+    get "List event_participants for an event_team" do
+      tags "EventParticipants"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "event_participants listed" do
+        let(:user_record) { create(:user) }
+        let(:event_record) { create(:event, user: user_record) }
+        let(:event_id) { event_record.id }
+        let(:event_team_id) { event_record.event_teams.find_by!(slot: "team_one").id }
+        let(:Authorization) { api_auth_headers_for(user_record)["Authorization"] }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/sessions_spec.rb
+++ b/spec/requests/api/v1/sessions_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Api::V1 Sessions", type: :request do
+  path "/api/v1/users/sign_in" do
+    post "Sign in" do
+      tags "Users"
+      consumes "application/json"
+      produces "application/json"
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          user: {
+            type: :object,
+            properties: {
+              email: { type: :string },
+              password: { type: :string }
+            },
+            required: %w[email password]
+          }
+        }
+      }
+
+      response "200", "signed in" do
+        let(:user_record) { create(:user) }
+        let(:user) { { user: { email: user_record.email, password: "password123" } } }
+
+        run_test! do |response|
+          expect(response.headers["Authorization"]).to be_present
+          expect(JSON.parse(response.body)).to include("email" => user_record.email)
+        end
+      end
+
+      response "401", "invalid credentials" do
+        let(:user) { { user: { email: "nope@example.com", password: "wrong" } } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/users/sign_out" do
+    delete "Sign out" do
+      tags "Users"
+      security [ bearer_auth: [] ]
+      produces "application/json"
+
+      response "204", "signed out" do
+        let(:user_record) { create(:user) }
+        let(:Authorization) { api_auth_headers_for(user_record)["Authorization"] }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1 Users", type: :request do
+  describe "POST /api/v1/users" do
+    it "registers a user" do
+      expect {
+        post "/api/v1/users", params: {
+          user: {
+            email: "new.player@example.com",
+            password: "password123",
+            password_confirmation: "password123",
+            first_name: "Ada",
+            last_name: "Lovelace"
+          }
+        }, as: :json
+      }.to change(User, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)).to include("email" => "new.player@example.com", "first_name" => "Ada")
+    end
+  end
+
+  describe "GET /api/v1/me" do
+    it "returns the current user" do
+      user = create(:user)
+      api_get "/api/v1/me", user: user
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include("id" => user.id, "email" => user.email)
+    end
+
+    it "rejects unauthenticated requests" do
+      get "/api/v1/me", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "PATCH /api/v1/me" do
+    it "updates the current user profile" do
+      user = create(:user)
+      api_patch "/api/v1/me", user: user, params: { user: { first_name: "Updated" } }
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.first_name).to eq("Updated")
+    end
+  end
+
+  describe "GET /api/v1/users/:id" do
+    it "returns the user" do
+      user = create(:user)
+      other = create(:user)
+      api_get "/api/v1/users/#{other.id}", user: user
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include("id" => other.id)
+    end
+  end
+end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -54,7 +54,14 @@ RSpec.describe "Api::V1 Users", type: :request do
       api_get "/api/v1/users/#{other.id}", user: user
 
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to include("id" => other.id)
+      body = JSON.parse(response.body)
+      expect(body).to include(
+        "id" => other.id,
+        "first_name" => other.first_name,
+        "last_name" => other.last_name,
+        "username" => other.username
+      )
+      expect(body).not_to include("email", "role")
     end
   end
 end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ApiHelpers
+  def api_auth_headers_for(user, password: "password123")
+    post "/api/v1/users/sign_in",
+         params: { user: { email: user.email, password: password } },
+         as: :json
+
+    auth = response.headers["Authorization"]
+    raise "JWT missing for #{user.email}: #{response.status} #{response.body}" if auth.blank?
+
+    { "Authorization" => auth }
+  end
+
+  def api_get(path, user:, params: nil, headers: {})
+    get path, params: params, headers: api_auth_headers_for(user).merge(headers), as: :json
+  end
+
+  def api_post(path, user:, params: nil, headers: {})
+    post path, params: params, headers: api_auth_headers_for(user).merge(headers), as: :json
+  end
+
+  def api_patch(path, user:, params: nil, headers: {})
+    patch path, params: params, headers: api_auth_headers_for(user).merge(headers), as: :json
+  end
+
+  def api_delete(path, user:, params: nil, headers: {})
+    delete path, params: params, headers: api_auth_headers_for(user).merge(headers), as: :json
+  end
+end
+
+RSpec.configure do |config|
+  config.include ApiHelpers, type: :request
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.configure do |config|
+  config.openapi_root = Rails.root.join("swagger").to_s
+
+  config.openapi_specs = {
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
+      info: {
+        title: "FlipFlapp API V1",
+        version: "v1",
+        description: "JSON API for FlipFlapp iOS/Android clients. Resource names mirror the web app (Convention over Configuration)."
+      },
+      paths: {},
+      components: {
+        securitySchemes: {
+          bearer_auth: {
+            type: :http,
+            scheme: :bearer,
+            bearerFormat: "JWT"
+          }
+        }
+      },
+      servers: [
+        {
+          url: "http://{defaultHost}",
+          variables: {
+            defaultHost: {
+              default: "localhost:3000"
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  config.openapi_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,177 @@
+---
+openapi: 3.0.1
+info:
+  title: FlipFlapp API V1
+  version: v1
+  description: JSON API for FlipFlapp iOS/Android clients. Resource names mirror the
+    web app (Convention over Configuration).
+paths:
+  "/api/v1/events":
+    get:
+      summary: List events
+      tags:
+      - Events
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: events listed
+        '401':
+          description: unauthorized
+    post:
+      summary: Create event
+      tags:
+      - Events
+      security:
+      - bearer_auth: []
+      parameters: []
+      responses:
+        '201':
+          description: event created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                event:
+                  type: object
+                  properties:
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    location:
+                      type: string
+                    start_time:
+                      type: string
+                      format: date-time
+                    number_of_participants:
+                      type: integer
+                    price:
+                      type: number
+                    is_private:
+                      type: boolean
+                    latitude:
+                      type: number
+                    longitude:
+                      type: number
+                  required:
+                  - title
+                  - location
+                  - start_time
+                  - number_of_participants
+                  - price
+                  - latitude
+                  - longitude
+  "/api/v1/events/{id}":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Show event
+      tags:
+      - Events
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: event found
+  "/api/v1/me":
+    get:
+      summary: Current user
+      tags:
+      - Users
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: current user
+  "/api/v1/events/{event_id}/event_teams":
+    parameters:
+    - name: event_id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: List event_teams
+      tags:
+      - EventTeams
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: event_teams listed
+  "/api/v1/events/{event_id}/event_teams/{event_team_id}/event_participants":
+    parameters:
+    - name: event_id
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: event_team_id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: List event_participants for an event_team
+      tags:
+      - EventParticipants
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: event_participants listed
+  "/api/v1/users/sign_in":
+    post:
+      summary: Sign in
+      tags:
+      - Users
+      parameters: []
+      responses:
+        '200':
+          description: signed in
+        '401':
+          description: invalid credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+                    password:
+                      type: string
+                  required:
+                  - email
+                  - password
+  "/api/v1/users/sign_out":
+    delete:
+      summary: Sign out
+      tags:
+      - Users
+      security:
+      - bearer_auth: []
+      responses:
+        '204':
+          description: signed out
+components:
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+servers:
+- url: http://{defaultHost}
+  variables:
+    defaultHost:
+      default: localhost:3000


### PR DESCRIPTION
- Introduced a new JSON API under `/api/v1` for mobile clients, utilizing Bearer JWT for authentication via `devise-jwt`.
- Created controllers for handling users, events, friendships, notifications, and invitations, ensuring resource names mirror web counterparts.
- Added serializers for API responses, maintaining a consistent structure with user and event data.
- Updated routes to include API endpoints and integrated Swagger UI for interactive API documentation.
- Enhanced documentation in `API.md` to outline conventions, authentication, error handling, and resource specifications.
- Configured CORS and Devise for JWT support, ensuring secure API access.
- Added migration for JWT denylist to manage token revocation.