### PR TITLE
feat(mailers): enhance email templates and add brand images

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,6 +3,14 @@
 class ApplicationMailer < ActionMailer::Base
   default from: -> { ENV["SMTP_USERNAME"].presence || "noreply@flipflapp.fr" }
   layout "mailer"
+  before_action :attach_brand_images
 
   # Always use deliver_later (Active Job / Solid Queue). Prefer deliver_now only in console/debug.
+
+  private
+
+  def attach_brand_images
+    attachments.inline["flipflapp_email.jpg"] = Rails.root.join("public/mailer/flipflapp_email.jpg").binread
+    attachments.inline["flipflapp_logo.png"] = Rails.root.join("public/mailer/flipflapp_logo.png").binread
+  end
 end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -6,9 +6,9 @@
 
 <p><%= t(".body") %></p>
 
-<p style="text-align: center;">
+<p class="action">
   <%= link_to t(".cta"), confirmation_url(@resource, confirmation_token: @token), class: "btn" %>
 </p>
 
-<p style="text-align: center;"><%= t(".ignore") %></p>
-<p style="text-align: center;"><%= t(".after_confirm") %></p>
+<p class="note"><%= t(".ignore") %></p>
+<p class="note"><%= t(".after_confirm") %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -14,8 +14,8 @@
   <p><%= t(".confirmed_note") %></p>
 <% end %>
 
-<p style="text-align: center;">
+<p class="action">
   <%= link_to t(".cta"), unauthenticated_root_url, class: "btn" %>
 </p>
 
-<p style="text-align: center;"><%= t(".warning") %></p>
+<p class="note"><%= t(".warning") %></p>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -8,8 +8,8 @@
 
 <p><%= t(".source") %></p>
 
-<p style="text-align: center;">
+<p class="action">
   <%= link_to t(".cta"), unauthenticated_root_url, class: "btn" %>
 </p>
 
-<p style="text-align: center;"><%= t(".warning") %></p>
+<p class="note"><%= t(".warning") %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -8,9 +8,9 @@
 
 <p><%= t(".instructions") %></p>
 
-<p style="text-align: center;">
+<p class="action">
   <%= link_to t(".cta"), edit_password_url(@resource, reset_password_token: @token), class: "btn" %>
 </p>
 
-<p style="text-align: center;"><%= t(".ignore") %></p>
-<p style="text-align: center;"><%= t(".unchanged") %></p>
+<p class="note"><%= t(".ignore") %></p>
+<p class="note"><%= t(".unchanged") %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -8,8 +8,8 @@
 
 <p><%= t(".instructions") %></p>
 
-<p style="text-align: center;">
+<p class="action">
   <%= link_to t(".cta"), unlock_url(@resource, unlock_token: @token), class: "btn" %>
 </p>
 
-<p style="text-align: center;"><%= t(".after_unlock") %></p>
+<p class="note"><%= t(".after_unlock") %></p>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -2,81 +2,149 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= content_for(:title) || t("devise.mailer.layout.default_title") %></title>
     <style>
       body {
         margin: 0;
         padding: 0;
-        background-color: #fafafa;
-        font-family: Arial, Helvetica, sans-serif;
-        color: #333;
-        line-height: 1.5;
+        width: 100%;
+        background-color: #eef2e8;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, Helvetica, sans-serif;
+        color: #243019;
+        line-height: 1.6;
       }
-      .container {
+      table {
+        border-collapse: collapse;
+        border-spacing: 0;
+      }
+      img {
+        border: 0;
+        display: block;
+        outline: none;
+        text-decoration: none;
+      }
+      .email-shell {
+        width: 100%;
+        background-color: #eef2e8;
+      }
+      .email-card {
+        width: 100%;
         max-width: 600px;
-        margin: auto;
-        background: #fff;
-        padding: 20px;
-        border-radius: 12px;
+        background-color: #ffffff;
+        border-radius: 24px;
+        box-shadow: 0 14px 38px rgba(45, 70, 8, 0.14);
+        overflow: hidden;
       }
-      header img {
-        max-width: 100%;
+      .brand-header {
+        background-color: #3a5f0b;
+      }
+      .brand-banner {
+        width: 100%;
         height: auto;
-        border-radius: 8px;
+      }
+      .content {
+        padding: 42px 48px 34px;
       }
       h1 {
-        font-size: 24px;
+        margin: 0 0 24px;
+        color: #2d4608;
+        font-size: 28px;
+        line-height: 1.25;
+        letter-spacing: -0.4px;
         text-align: center;
-        margin: 20px 0;
-        color: #000;
       }
       p {
         font-size: 16px;
-        margin: 10px 0;
+        margin: 0 0 16px;
       }
       .btn {
         display: inline-block;
-        margin: 20px auto;
-        padding: 12px 24px;
-        background: #ff7c00;
-        color: #fff;
-        font-size: 18px;
-        font-weight: bold;
+        padding: 14px 26px;
+        background-color: #f4d35e;
+        border: 1px solid #cca508;
+        border-radius: 14px;
+        color: #243019 !important;
+        font-size: 16px;
+        font-weight: 700;
         text-decoration: none;
-        border-radius: 16px;
         text-align: center;
       }
-      footer {
+      .action {
         text-align: center;
+        padding: 10px 0 18px;
+      }
+      .note {
+        color: #617052;
         font-size: 14px;
-        margin-top: 30px;
-        color: #666;
+        text-align: center;
       }
-      footer a {
-        color: #5C68E2;
+      .footer {
+        padding: 26px 32px 30px;
+        background-color: #2d4608;
+        color: #e0e7cc;
+        font-size: 13px;
+        text-align: center;
+      }
+      .footer p {
+        margin: 0;
+        font-size: 13px;
+      }
+      .footer a {
+        color: #f4d35e;
+        font-weight: 600;
+        text-decoration: none;
+      }
+      .footer-logo {
+        width: 64px;
+        height: 64px;
+        margin: 0 auto 14px;
       }
       @media (max-width: 600px) {
-        h1 { font-size: 20px; }
-        p { font-size: 14px; }
-        .btn { font-size: 16px; padding: 10px 20px; }
+        .outer-cell { padding: 16px 12px !important; }
+        .email-card { border-radius: 18px; }
+        .content { padding: 32px 24px 26px; }
+        h1 { font-size: 23px; }
+        p { font-size: 15px; }
+        .btn { display: block; padding: 13px 18px; }
       }
     </style>
   </head>
 
   <body>
-    <section class="container" role="main">
-      <header>
-        <%= image_tag "#{ActionMailer::Base.asset_host}/mailer/flipflapp_email.jpg", alt: t("devise.mailer.layout.banner_alt") %>
-      </header>
-
-      <main>
-        <%= yield %>
-      </main>
-
-      <footer role="contentinfo">
-        <p><%= t("devise.mailer.layout.powered_by") %> <%= link_to '#1344 Solutions', 'https://www.1344.fr', target: '_blank' %></p>
-        <%= image_tag "#{ActionMailer::Base.asset_host}/mailer/flipflapp_logo.png", alt: t("devise.mailer.layout.logo_alt"), width: 100, style: "margin-top:15px;" %>
-      </footer>
-    </section>
+    <table class="email-shell" role="presentation" width="100%">
+      <tr>
+        <td class="outer-cell" align="center" style="padding: 32px 16px;">
+          <table class="email-card" role="presentation" width="600">
+            <tr>
+              <td class="brand-header">
+                <%= image_tag attachments["flipflapp_email.jpg"].url,
+                              class: "brand-banner",
+                              alt: t("devise.mailer.layout.banner_alt"),
+                              width: 600 %>
+              </td>
+            </tr>
+            <tr>
+              <td class="content" role="main">
+                <%= yield %>
+              </td>
+            </tr>
+            <tr>
+              <td class="footer" role="contentinfo">
+                <%= image_tag attachments["flipflapp_logo.png"].url,
+                              class: "footer-logo",
+                              alt: t("devise.mailer.layout.logo_alt"),
+                              width: 64,
+                              height: 64 %>
+                <p>
+                  <%= t("devise.mailer.layout.powered_by") %>
+                  <%= link_to "#1344 Solutions", "https://www.1344.fr", target: "_blank", rel: "noopener" %>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>


### PR DESCRIPTION
This pull request updates the application's email system to provide a more polished and branded experience for users. The main changes include attaching brand images to all outgoing emails, redesigning the email layout for improved appearance and responsiveness, and standardizing the styling of Devise mailer templates.

**Email branding and layout improvements:**

* [`app/mailers/application_mailer.rb`](diffhunk://#diff-45168f66de21a32e4bee597d3db35eed44a4de0980564be08b5cb0a512e6889fR6-R15): Brand images (`flipflapp_email.jpg` and `flipflapp_logo.png`) are now attached inline to all outgoing emails, ensuring consistent branding in email headers and footers.
* [`app/views/layouts/mailer.html.erb`](diffhunk://#diff-be08706a5d0df9b30287a13aef56575edc484aae67bc333504f15da84649efd5R5-R148): The email layout has been completely redesigned for a modern look and improved mobile responsiveness. It now features a branded header and footer with inline images, updated color scheme, and improved typography and spacing.

**Standardization and improved styling for Devise mailer templates:**

* All Devise mailer templates (`confirmation_instructions.html.erb`, `email_changed.html.erb`, `password_change.html.erb`, `reset_password_instructions.html.erb`, `unlock_instructions.html.erb`) now use consistent CSS classes (`.action`, `.note`) instead of inline `style` attributes for better maintainability and appearance. [[1]](diffhunk://#diff-95ae6c59790681dcff02cd8b257d62d6ba5e8af933e4088a6716207092b3bc6bL9-R14) [[2]](diffhunk://#diff-83e73c71d7b3b464031a24b2616b9d945db8b2455cd5e6acacd0656db15abf5bL17-R21) [[3]](diffhunk://#diff-764ca0ae3e1cb7734ecd75796ea8a64ec13833fddd9f420c45d6c7ec7a14559fL11-R15) [[4]](diffhunk://#diff-8c6a8281243e6aa950c189a4bf72266c0a4eda2c562145961463e614ba7826f1L11-R16) [[5]](diffhunk://#diff-724fd47d338e31872300aee2fc471c434061f9ad1f7041620c7467c635346b94L11-R15)